### PR TITLE
Feature(HK-63): Footer 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import './App.css';
-import Header from './components/header';
+import Main from './pages/main';
 
 const App: React.FC = () => {
   return (
     <div className="App">
-      <Header />
+      <Main />
     </div>
   );
 };

--- a/src/components/footer/index.style.tsx
+++ b/src/components/footer/index.style.tsx
@@ -1,0 +1,6 @@
+import { Button } from 'antd';
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const Link = styled(Button)``;

--- a/src/components/footer/index.style.tsx
+++ b/src/components/footer/index.style.tsx
@@ -1,6 +1,26 @@
 import { Button } from 'antd';
 import styled from 'styled-components';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  width: 100%;
+  padding: 20px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 100px;
+`;
 
-export const Link = styled(Button)``;
+export const Link = styled(Button)`
+  border-radius: 0;
+  padding: 0;
+  height: auto;
+  border: none;
+  background: transparent;
+  position: relative;
+
+  &:hover,
+  &:focus {
+    background: transparent;
+    border: none;
+  }
+`;

--- a/src/components/footer/index.style.tsx
+++ b/src/components/footer/index.style.tsx
@@ -3,11 +3,19 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   width: 100%;
+  height: 80px;
   padding: 20px 0;
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 100px;
+  border-top: 1px solid #e8e8e8;
+`;
+
+export const Divider = styled.div`
+  width: 1px;
+  height: 20px;
+  background: #e8e8e8;
 `;
 
 export const Link = styled(Button)`

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,0 +1,16 @@
+import { Container, Link } from './index.style';
+
+const Footer = () => {
+  return (
+    <>
+      <Container>
+        <Link type="text">© Team Dopamine.</Link>
+        <Link type="text">서비스 피드백</Link>
+        <Link type="text">이용약관</Link>
+        <Link type="text">개인정보처리방침</Link>
+      </Container>
+    </>
+  );
+};
+
+export default Footer;

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -5,8 +5,11 @@ const Footer = () => {
     <>
       <Container>
         <Link type="text">© Team Dopamine.</Link>
+        <span>|</span>
         <Link type="text">서비스 피드백</Link>
+        <span>|</span>
         <Link type="text">이용약관</Link>
+        <span>|</span>
         <Link type="text">개인정보처리방침</Link>
       </Container>
     </>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,15 +1,15 @@
-import { Container, Link } from './index.style';
+import { Container, Divider, Link } from './index.style';
 
 const Footer = () => {
   return (
     <>
       <Container>
         <Link type="text">© Team Dopamine.</Link>
-        <span>|</span>
+        <Divider />
         <Link type="text">서비스 피드백</Link>
-        <span>|</span>
+        <Divider />
         <Link type="text">이용약관</Link>
-        <span>|</span>
+        <Divider />
         <Link type="text">개인정보처리방침</Link>
       </Container>
     </>

--- a/src/pages/main/index.style.tsx
+++ b/src/pages/main/index.style.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Content = styled.div`
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+`;

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,0 +1,14 @@
+import Header from '../../components/header';
+import Footer from '../../components/footer';
+
+const Main = () => {
+  return (
+    <>
+      <Header />
+      {/* Contents */}
+      <Footer />
+    </>
+  );
+};
+
+export default Main;

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,12 +1,15 @@
 import Header from '../../components/header';
 import Footer from '../../components/footer';
+import { Content, Layout } from './index.style';
 
 const Main = () => {
   return (
     <>
-      <Header />
-      {/* Contents */}
-      <Footer />
+      <Layout>
+        <Header />
+        <Content>Empty</Content>
+        <Footer />
+      </Layout>
     </>
   );
 };


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- [HK-63](https://team-dopamine.atlassian.net/browse/HK-63?atlOrigin=eyJpIjoiZDVlMDZiNzNjMDQ3NGE1N2E1MDhlMjFmZTA5MzE3NWYiLCJwIjoiaiJ9)
- 서비스 약관, 사용자 지원, 보조 네비게이션을 포함하는 컴포넌트 필요성 대두

## Problem Solving

<!-- 해결 방법 -->

- Footer 컴포넌트 구현
- Main 페이지 레이아웃 구현

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

1. AWS Amplify에서 Header와 Footer를 포함하는 UI를 확인하기 위해 MainPage 레이아웃을 가볍게 구현해 보았습니다.
  - 추후 MainPage 상세 구현 시에는 수정하셔도 무방합니다.
2. 현재 `@Components`, `@Page`와 같은 절대 경로가 동작하지 않고 있습니다. 
  ```
  ERROR in ./src/pages/main/index.tsx 5:0-40
Module not found: Error: Can't resolve '@components/footer' in '/Users/jinu/Desktop/workspace/dopamine/husk-web/src/pages/main'
  ```
  - 따라서 우선적으로는 상대 경로로 구현(`'../../components/footer';`)하였으나 별도 PR을 통해 버그 픽스을 위한 작업을 해야할 것 같습니다.

[HK-63]: https://team-dopamine.atlassian.net/browse/HK-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ