### PR TITLE
Feature(HK-70): 일반 회원가입 이메일 인증 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import './App.css';
-import Main from './pages/main';
+import Main from '@pages/main';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import SignIn from './pages/sign-in';
+import SignIn from '@pages/sign-in';
+import SignUp from '@pages/sign-up';
 
 const App: React.FC = () => {
   return (
@@ -11,6 +12,7 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/" element={<Main />}></Route>
           <Route path="/sign-in" element={<SignIn />}></Route>
+          <Route path="/sign-up" element={<SignUp />}></Route>
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/sign-up/email-verify/index.style.tsx
+++ b/src/components/sign-up/email-verify/index.style.tsx
@@ -1,0 +1,103 @@
+import styled from 'styled-components';
+import { Button, Input } from 'antd';
+
+const ButtonStyle = styled(Button)`
+  width: 80px;
+  height: 36px;
+  border-radius: 8px;
+  color: black;
+  background-color: white;
+  border: 1px solid black;
+  font-size: 11px;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  &:hover {
+    background-color: gray !important;
+    color: white !important;
+    border: none;
+  }
+`;
+
+const WrapperStyle = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const InputStyle = styled(Input)`
+  width: 492px;
+  height: 36px;
+  border-radius: 6px;
+  padding: 8px 12px 8px 12px;
+
+  &:focus,
+  &:hover {
+    border: 1px solid gray !important;
+  }
+  &:disabled {
+    border: 1px solid lightgray;
+    &:hover {
+      border: 1px solid lightgray !important;
+    }
+  }
+`;
+
+export const FormContainer = styled.div<{ showCodeVerify: boolean }>`
+  width: 492px;
+  height: 60px;
+  gap: 4px;
+  margin-bottom: ${(props) => (props.showCodeVerify ? '104px' : '5px')};
+`;
+
+export const Label = styled.div`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  display: flex;
+  text-align: left;
+  margin-bottom: 4px;
+`;
+
+export const EmailFieldWrapper = styled(WrapperStyle)``;
+
+export const EmailWrapper = styled(WrapperStyle)`
+  margin-bottom: 25px;
+  flex-direction: column;
+`;
+
+export const VerifyWrapper = styled(WrapperStyle)``;
+
+export const InputField = styled(InputStyle)`
+  width: 400px;
+  height: 36px;
+  border-radius: 8px;
+`;
+
+export const RequestCodeButton = styled(ButtonStyle)`
+  &:disabled {
+    cursor: not-allowed;
+    background-color: lightgray;
+    color: darkgray;
+    border: none;
+    &:hover {
+      background-color: lightgray !important;
+      color: darkgray !important;
+    }
+  }
+`;
+
+export const VerifyButton = styled(ButtonStyle)``;
+
+export const Timer = styled.div`
+  font-size: 14px;
+  margin-top: 5px;
+  text-align: right;
+  color: gray;
+`;
+
+export const Message = styled(Label)`
+  color: gray;
+  margin: 0;
+`;

--- a/src/components/sign-up/email-verify/index.tsx
+++ b/src/components/sign-up/email-verify/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import { EmailWrapper, FormContainer, Label, InputField, RequestCodeButton, VerifyWrapper, VerifyButton, Timer, EmailFieldWrapper, Message } from './index.style';
+
+interface EmailVerifyProps {
+  onInputChange: (email: string, code: string) => void;
+}
+
+const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [showCodeVerify, setShowCodeVerify] = useState(false);
+  const [timer, setTimer] = useState(300);
+  const [alertShown, setAlertShown] = useState(false);
+  const [emailDisabled, setEmailDisabled] = useState(false);
+
+  //   TODO: Hook 컴포넌트 분리
+
+  useEffect(() => {
+    const savedTimer = sessionStorage.getItem('timer');
+    const savedEmailDisabled = sessionStorage.getItem('emailDisabled');
+    const savedShowCodeVerify = sessionStorage.getItem('showCodeVerify');
+
+    if (savedTimer && Number(savedTimer) > 0) {
+      setTimer(Number(savedTimer));
+    } else {
+      setTimer(0);
+    }
+
+    setEmailDisabled(savedEmailDisabled === 'true' && Number(savedTimer) > 0);
+
+    if (savedShowCodeVerify === 'true' && Number(savedTimer) > 0) {
+      setShowCodeVerify(true);
+    } else {
+      setShowCodeVerify(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem('timer', timer.toString());
+    sessionStorage.setItem('emailDisabled', emailDisabled.toString());
+    sessionStorage.setItem('showCodeVerify', showCodeVerify.toString());
+
+    if (showCodeVerify && timer > 0) {
+      const interval = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+
+      return () => clearInterval(interval);
+    } else if (timer === 0 && !alertShown) {
+      alert('인증 코드가 만료되었습니다. 다시 요청해주세요.');
+      setShowCodeVerify(false);
+      setEmailDisabled(false);
+      setAlertShown(true);
+      sessionStorage.clear();
+    }
+  }, [showCodeVerify, timer, alertShown, emailDisabled]);
+
+  const handleRequestCode = () => {
+    setShowCodeVerify(true);
+    setTimer(300);
+    setAlertShown(false);
+    setEmailDisabled(true);
+  };
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setEmail(value);
+    onInputChange(value, code);
+  };
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setCode(value);
+    onInputChange(email, value);
+  };
+
+  const formatTime = (time: number): string => {
+    const minutes = Math.floor(time / 60);
+    const seconds = time % 60;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  };
+
+  return (
+    <FormContainer showCodeVerify={showCodeVerify}>
+      <Label>Email</Label>
+      <EmailWrapper>
+        <EmailFieldWrapper>
+          <InputField id="email" type="email" placeholder="Enter your Email" value={email} onChange={handleEmailChange} disabled={emailDisabled} />
+          <RequestCodeButton type="primary" onClick={handleRequestCode} disabled={emailDisabled}>
+            Request Code
+          </RequestCodeButton>
+        </EmailFieldWrapper>
+        {emailDisabled && <Message>Send the Verify Code</Message>}
+      </EmailWrapper>
+
+      {showCodeVerify && (
+        <>
+          <Label>Verify Code</Label>
+          <VerifyWrapper>
+            <InputField id="code" type="text" placeholder="Code" value={code} onChange={handleCodeChange} />
+            <VerifyButton type="primary">Verify</VerifyButton>
+            {/* TODO: API 연결 후 Verify 클릭 시 인증 성공 알림*/}
+          </VerifyWrapper>
+          <Timer>{formatTime(timer)}</Timer>
+        </>
+      )}
+    </FormContainer>
+  );
+};
+
+export default EmailVerify;

--- a/src/components/sign-up/index.style.tsx
+++ b/src/components/sign-up/index.style.tsx
@@ -1,0 +1,103 @@
+import styled from 'styled-components';
+import { Button, Input } from 'antd';
+
+const ButtonStyle = styled(Button)`
+  width: 80px;
+  height: 36px;
+  border-radius: 8px;
+  color: black;
+  background-color: white;
+  border: 1px solid black;
+  font-size: 11px;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  &:hover {
+    background-color: gray !important;
+    color: white !important;
+    border: none;
+  }
+`;
+
+const WrapperStyle = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const InputStyle = styled(Input)`
+  width: 492px;
+  height: 36px;
+  border-radius: 6px;
+  padding: 8px 12px 8px 12px;
+
+  &:focus,
+  &:hover {
+    border: 1px solid gray !important;
+  }
+  &:disabled {
+    border: 1px solid lightgray;
+    &:hover {
+      border: 1px solid lightgray !important;
+    }
+  }
+`;
+
+export const FormContainer = styled.div<{ showCodeVerify: boolean }>`
+  width: 492px;
+  height: 60px;
+  gap: 4px;
+  margin-bottom: ${(props) => (props.showCodeVerify ? '104px' : '5px')};
+`;
+
+export const Label = styled.div`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  display: flex;
+  text-align: left;
+  margin-bottom: 4px;
+`;
+
+export const EmailFieldWrapper = styled(WrapperStyle)``;
+
+export const EmailWrapper = styled(WrapperStyle)`
+  margin-bottom: 25px;
+  flex-direction: column;
+`;
+
+export const VerifyWrapper = styled(WrapperStyle)``;
+
+export const InputField = styled(InputStyle)`
+  width: 400px;
+  height: 36px;
+  border-radius: 8px;
+`;
+
+export const RequestCodeButton = styled(ButtonStyle)`
+  &:disabled {
+    cursor: not-allowed;
+    background-color: lightgray;
+    color: darkgray;
+    border: none;
+    &:hover {
+      background-color: lightgray !important;
+      color: darkgray !important;
+    }
+  }
+`;
+
+export const VerifyButton = styled(ButtonStyle)``;
+
+export const Timer = styled.div`
+  font-size: 14px;
+  margin-top: 5px;
+  text-align: right;
+  color: gray;
+`;
+
+export const Message = styled(Label)`
+  color: gray;
+  margin: 0;
+`;

--- a/src/components/sign-up/index.tsx
+++ b/src/components/sign-up/index.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+import { EmailWrapper, FormContainer, Label, InputField, RequestCodeButton, VerifyWrapper, VerifyButton, Timer, EmailFieldWrapper, Message } from './index.style';
+
+interface EmailVerifyProps {
+  onInputChange: (email: string, code: string) => void;
+}
+
+const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [showCodeVerify, setShowCodeVerify] = useState(false);
+  const [timer, setTimer] = useState(300);
+  const [alertShown, setAlertShown] = useState(false);
+  const [emailDisabled, setEmailDisabled] = useState(false);
+
+  //   TODO: Hook 컴포넌트 분리
+
+  useEffect(() => {
+    const savedTimer = sessionStorage.getItem('timer');
+    const savedEmailDisabled = sessionStorage.getItem('emailDisabled');
+    const savedShowCodeVerify = sessionStorage.getItem('showCodeVerify');
+
+    if (savedTimer && Number(savedTimer) > 0) {
+      setTimer(Number(savedTimer));
+    } else {
+      setTimer(0);
+    }
+
+    if (savedEmailDisabled === 'true' && Number(savedTimer) > 0) {
+      setEmailDisabled(true);
+    } else {
+      setEmailDisabled(false);
+    }
+
+    if (savedShowCodeVerify === 'true' && Number(savedTimer) > 0) {
+      setShowCodeVerify(true);
+    } else {
+      setShowCodeVerify(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem('timer', timer.toString());
+    sessionStorage.setItem('emailDisabled', emailDisabled.toString());
+    sessionStorage.setItem('showCodeVerify', showCodeVerify.toString());
+
+    if (showCodeVerify && timer > 0) {
+      const interval = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+
+      return () => clearInterval(interval);
+    } else if (timer === 0 && !alertShown) {
+      alert('인증 코드가 만료되었습니다. 다시 요청해주세요.');
+      setShowCodeVerify(false);
+      setEmailDisabled(false);
+      setAlertShown(true);
+      sessionStorage.clear();
+    }
+  }, [showCodeVerify, timer, alertShown, emailDisabled]);
+
+  const handleRequestCode = () => {
+    setShowCodeVerify(true);
+    setTimer(300);
+    setAlertShown(false);
+    setEmailDisabled(true);
+  };
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setEmail(value);
+    onInputChange(value, code);
+  };
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setCode(value);
+    onInputChange(email, value);
+  };
+
+  const formatTime = (time: number): string => {
+    const minutes = Math.floor(time / 60);
+    const seconds = time % 60;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  };
+
+  return (
+    <FormContainer showCodeVerify={showCodeVerify}>
+      <Label>Email</Label>
+      <EmailWrapper>
+        <EmailFieldWrapper>
+          <InputField id="email" type="email" placeholder="Enter your Email" value={email} onChange={handleEmailChange} disabled={emailDisabled} />
+          <RequestCodeButton type="primary" onClick={handleRequestCode} disabled={emailDisabled}>
+            Request Code
+          </RequestCodeButton>
+        </EmailFieldWrapper>
+        {emailDisabled && <Message>Send the Verify Code</Message>}
+      </EmailWrapper>
+
+      {showCodeVerify && (
+        <>
+          <Label>Verify Code</Label>
+          <VerifyWrapper>
+            <InputField id="code" type="text" placeholder="Code" value={code} onChange={handleCodeChange} />
+            <VerifyButton type="primary">Verify</VerifyButton>
+            {/* TODO: API 연결 후 Verify 클릭 시 인증 성공 알림*/}
+          </VerifyWrapper>
+          <Timer>{formatTime(timer)}</Timer>
+        </>
+      )}
+    </FormContainer>
+  );
+};
+
+export default EmailVerify;

--- a/src/pages/sign-up/content/index.style.tsx
+++ b/src/pages/sign-up/content/index.style.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { Button } from 'antd';
+
+const ButtonStyle = styled(Button)`
+  width: 240px;
+  height: 48px;
+  border-radius: 8px !important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 300px);
+  flex: 1;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 400px;
+  width: 100%;
+`;
+
+export const Title = styled.h1`
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 48px;
+  text-align: center;
+`;
+export const ButtonGroup = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 60px;
+`;
+export const PreviousButton = styled(ButtonStyle)`
+  color: black;
+  text-decoration: none;
+  border: 1px solid black;
+  background-color: white;
+
+  &:hover {
+    background-color: gray !important;
+    color: white !important;
+    border: none;
+  }
+`;
+
+export const NextButton = styled.button<{ disabled: boolean }>`
+  width: 240px;
+  height: 48px;
+  border-radius: 8px;
+  border: ${({ disabled }) => (disabled ? '1px #d9d9d9' : '1px solid black')};
+  background-color: ${({ disabled }) => (disabled ? '#d9d9d9' : 'black')};
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+`;

--- a/src/pages/sign-up/content/index.tsx
+++ b/src/pages/sign-up/content/index.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Container, ContentWrapper, Title, PreviousButton, NextButton, ButtonGroup } from './index.style';
+import EmailVerify from '@components/sign-up';
+
+const Content = () => {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+
+  const handleInputChange = (email: string, code: string) => {
+    setEmail(email);
+    setCode(code);
+  };
+
+  const isNextButtonDisabled = email.trim() === '' || code.trim() === '';
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Title>Sign Up</Title>
+        <EmailVerify onInputChange={handleInputChange} />
+        <ButtonGroup>
+          <PreviousButton type="primary" href="/sign-in">
+            Previous
+          </PreviousButton>
+          {/* TODO: 이메일 유효성 검증 후 다음 버튼 활성화 */}
+          <NextButton type="submit" disabled={isNextButtonDisabled}>
+            Next
+          </NextButton>
+        </ButtonGroup>
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default Content;

--- a/src/pages/sign-up/index.style.tsx
+++ b/src/pages/sign-up/index.style.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;

--- a/src/pages/sign-up/index.tsx
+++ b/src/pages/sign-up/index.tsx
@@ -1,0 +1,18 @@
+import Header from '@components/header';
+import Footer from '@components/footer';
+import { Layout } from './index.style';
+import Content from './content';
+
+const SignIn = () => {
+  return (
+    <>
+      <Layout>
+        <Header />
+        <Content />
+        <Footer />
+      </Layout>
+    </>
+  );
+};
+
+export default SignIn;


### PR DESCRIPTION
## Motivation

- [Jira's HK-70 참고](https://team-dopamine.atlassian.net/browse/HK-70?atlOrigin=eyJpIjoiMjE2MjBkMDE0ZmRlNDlhMWI5MzcyMmQxY2RiMjg1YzYiLCJwIjoiaiJ9)
- 사용자가 이메일 인증 코드를 통해 유효성을 검증하여 회원가입을 진행하기 위한 페이지 구현

## Problem Solving

- 회원가입 페이지 router 설정(cb292c486612383924b6801c0270481837afcd92)
- 사용자로부터 이메일을 입력 받아 해당 이메일로 인증코드를 보낼 수 있는 페이지 구현(aa206a6)
- `previous`, `Next`버튼을 통해 페이지 이동(aa206a6)

## To Reviewer

-  Api 연결 후 따로 수정해야 할 부분은 `TODO:` 를 통해 기록해두었음. 추후 api 연결 시 수정 예정.
- 이메일 인증 페이지만 우선 구현해뒀는데 다음 단계 페이지(`Ex.비밀번호 설정, 약관 동의, 아이디/비번 찾기`) 는 따로 브랜치를 파서 진행하는 건 어떨 지 의견 부탁드립니다!
