### PR TITLE
Feature(HK-81): 일반 회원가입 비밀번호 설정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Main from '@pages/main';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import SignIn from '@pages/sign-in';
 import SignUp from '@pages/sign-up';
+import Password from '@pages/sign-up/password';
 
 const App: React.FC = () => {
   return (
@@ -13,6 +14,8 @@ const App: React.FC = () => {
           <Route path="/" element={<Main />}></Route>
           <Route path="/sign-in" element={<SignIn />}></Route>
           <Route path="/sign-up" element={<SignUp />}></Route>
+          {/* TODO: 추후 경로 변경 */}
+          <Route path="/password" element={<Password />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/sign-up/password-setting/index.style.tsx
+++ b/src/components/sign-up/password-setting/index.style.tsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import { Input } from 'antd';
+
+const WrapperStyle = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const InputStyle = styled(Input)`
+  width: 492px;
+  height: 36px;
+  border-radius: 6px;
+  padding: 8px 12px 8px 12px;
+
+  &:focus,
+  &:hover {
+    border: 1px solid gray !important;
+  }
+  &:disabled {
+    border: 1px solid lightgray;
+    &:hover {
+      border: 1px solid lightgray !important;
+    }
+  }
+`;
+
+export const FormContainer = styled.div<{ showCodeVerify: boolean }>`
+  width: 492px;
+  height: 60px;
+  gap: 4px;
+  margin-bottom: ${(props) => (props.showCodeVerify ? '104px' : '5px')};
+`;
+
+export const Label = styled.div`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  display: flex;
+  text-align: left;
+  margin-bottom: 4px;
+`;
+
+export const PasswordWrapper = styled(WrapperStyle)`
+  margin-bottom: 25px;
+  flex-direction: column;
+`;
+
+export const InputField = styled(InputStyle)<{ isError: boolean }>`
+  border: 1px solid ${(props) => (props.isError ? 'red' : 'gray')};
+
+  &:focus {
+    border: 1px solid ${(props) => (props.isError ? 'red' : 'gray')} !important;
+  }
+`;
+
+export const Message = styled(Label)<{ isError: boolean }>`
+  color: ${(props) => (props.isError ? 'red' : 'gray')};
+  margin: 0;
+`;

--- a/src/components/sign-up/password-setting/index.tsx
+++ b/src/components/sign-up/password-setting/index.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { FormContainer, Label, InputField, Message, PasswordWrapper } from './index.style';
+
+const isValidPassword = (value: string): boolean => {
+  const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+  return regex.test(value);
+};
+
+const fields = [
+  { id: 'password', label: 'Password', placeholder: 'Enter your Password', showMessage: true },
+  { id: 'passwordVerify', label: 'Password Verify', placeholder: 'Verify your Password', showMessage: false },
+];
+
+const createInitialState = () => ({
+  inputs: { password: '', passwordVerify: '' },
+  isValid: { password: true, passwordVerify: true },
+  touched: { password: false, passwordVerify: false },
+});
+
+interface PasswordProps {
+  onInputChange: (password: string, passwordVerify: string) => void;
+}
+
+const PasswordSetting: React.FC<PasswordProps> = ({ onInputChange }) => {
+  const [state, setState] = useState(createInitialState);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setState((prev) => {
+      const updatedInputs = { ...prev.inputs, [id]: value };
+      const updatedIsValid = {
+        ...prev.isValid,
+        [id]: id === 'password' ? isValidPassword(value) : value === updatedInputs.password,
+      };
+      onInputChange(updatedInputs.password, updatedInputs.passwordVerify);
+
+      return { ...prev, inputs: updatedInputs, isValid: updatedIsValid };
+    });
+  };
+
+  const handleFocus = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      touched: { ...prev.touched, [id]: true },
+    }));
+  };
+  const renderMessage = (id: string, showMessage: boolean): React.ReactNode => {
+    if (!state.touched[id as keyof typeof state.touched]) return null;
+
+    if (showMessage && id === 'password' && !state.isValid.password) {
+      return <Message isError>8~16자 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다.</Message>;
+    }
+
+    if (id === 'passwordVerify' && !state.isValid.passwordVerify) {
+      return <Message isError>비밀번호가 일치하지 않습니다.</Message>;
+    }
+
+    return null;
+  };
+
+  return (
+    <FormContainer showCodeVerify={true}>
+      {fields.map(({ id, label, placeholder, showMessage }) => (
+        <PasswordWrapper key={id}>
+          <Label>{label}</Label>
+          <InputField
+            id={id}
+            type="password"
+            placeholder={placeholder}
+            value={state.inputs[id as keyof typeof state.inputs]}
+            isError={state.touched[id as keyof typeof state.touched] && !state.isValid[id as keyof typeof state.isValid]}
+            onChange={handleChange}
+            onFocus={() => handleFocus(id)}
+          />
+          {renderMessage(id, showMessage)}
+        </PasswordWrapper>
+      ))}
+    </FormContainer>
+  );
+};
+
+export default PasswordSetting;

--- a/src/pages/sign-up/password/index.style.tsx
+++ b/src/pages/sign-up/password/index.style.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;

--- a/src/pages/sign-up/password/index.tsx
+++ b/src/pages/sign-up/password/index.tsx
@@ -1,0 +1,18 @@
+import Header from '@components/header';
+import Footer from '@components/footer';
+import { Layout } from './index.style';
+import PasswordContent from './password-content';
+
+const Password = () => {
+  return (
+    <>
+      <Layout>
+        <Header />
+        <PasswordContent />
+        <Footer />
+      </Layout>
+    </>
+  );
+};
+
+export default Password;

--- a/src/pages/sign-up/password/password-content/index.style.tsx
+++ b/src/pages/sign-up/password/password-content/index.style.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { Button } from 'antd';
+
+const ButtonStyle = styled(Button)`
+  width: 240px;
+  height: 48px;
+  border-radius: 8px !important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 300px);
+  flex: 1;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 400px;
+  width: 100%;
+`;
+
+export const Title = styled.h1`
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 48px;
+  text-align: center;
+`;
+export const ButtonGroup = styled.div<{ isPasswordMismatch: boolean }>`
+  display: flex;
+  gap: 12px;
+  margin-top: ${({ isPasswordMismatch }) => (isPasswordMismatch ? '90px' : '60px')};
+`;
+export const PreviousButton = styled(ButtonStyle)`
+  color: black;
+  text-decoration: none;
+  border: 1px solid black;
+  background-color: white;
+
+  &:hover {
+    background-color: gray !important;
+    color: white !important;
+    border: none;
+  }
+`;
+
+export const NextButton = styled.button<{ disabled: boolean }>`
+  width: 240px;
+  height: 48px;
+  border-radius: 8px;
+  border: ${({ disabled }) => (disabled ? '1px #d9d9d9' : '1px solid black')};
+  background-color: ${({ disabled }) => (disabled ? '#d9d9d9' : 'black')};
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+`;

--- a/src/pages/sign-up/password/password-content/index.tsx
+++ b/src/pages/sign-up/password/password-content/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Container, ContentWrapper, Title, PreviousButton, NextButton, ButtonGroup } from './index.style';
+import PasswordSetting from '@components/sign-up/password-setting';
+
+const PasswordContent = () => {
+  const [password, setPassword] = useState('');
+  const [passwordVerify, setPasswordVerify] = useState('');
+
+  const handleInputChange = (password: string, passwordVerify: string) => {
+    setPassword(password);
+    setPasswordVerify(passwordVerify);
+  };
+
+  const isPasswordMismatch = password.trim() === '' || passwordVerify.trim() === '' || password !== passwordVerify;
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Title>Sign Up</Title>
+        <PasswordSetting onInputChange={handleInputChange} />
+        <ButtonGroup isPasswordMismatch={isPasswordMismatch}>
+          <PreviousButton type="primary" href="/sign-up">
+            Previous
+          </PreviousButton>
+          <NextButton type="submit" disabled={isPasswordMismatch}>
+            Next
+          </NextButton>
+        </ButtonGroup>
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default PasswordContent;


### PR DESCRIPTION
## Motivation

- [Jira's HK-81 참고](https://team-dopamine.atlassian.net/jira/software/projects/HK/boards/2/backlog?selectedIssue=HK-81&atlOrigin=eyJpIjoiNDIwZDQ5ZWJjYzQ4NDRmYTgyNWNlNjk3YzRiMWVhNGIiLCJwIjoiaiJ9)
- 사용자가 회원가입 시 비밀번호를 설정하기 위한 페이지 구현

## Problem Solving

- 비밀번호 설정 페이지 router 연결(ef107a890fcac7c17c045bc859031c8762edd051)
- 사용자로부터 사용할 비밀번호를 입력 받아 비밀번호 유효성 검사(274495bab6bb45146221511ba9c475fc6208334d)
- `previous`, `Next` 버튼을 통해 페이지 이동(76fd95bbc0452a7bf462e42eb681c84f12b76a67)

## To Reviewer

- 비밀번호 생성 조건은 **8~16자 영문 대 소문자, 숫자, 특수문자를 포함**으로 설정

:speech_balloon:
--


- 추후 리팩토링 작업 필요
     - 라우터 설정
     - 디렉토리 구조
     - 메인페이지, 로그인페이지, 회원가입 페이지에서 공통적으로 사용되는 요소(Header, Footer) 혹은 `ButtonGroup` 등은 공통 컴포넌트로 설정하면 구현할 때 더 편리해 질 것 같습니다!
