### PR TITLE
Fix(HK-78): deploy workflow의 trigger 브랜치와 ssh 접속 방식 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Continuous Deployment
 
 on:
   push:
-    branches: ['develop']
+    branches: ['main']
   workflow_dispatch:
     inputs:
       logLevel:
@@ -52,7 +52,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           port: ${{ secrets.SERVER_SSH_PORT }}
           username: ${{ secrets.SERVER_USERNAME }}
-          password: ${{ secrets.SERVER_PASSWORD }}
+          key: ${{ secrets.SERVER_KEY }}
           script: |
             sudo docker stop husk-web
             sudo docker rm husk-web


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [이전 PR](https://github.com/team-dopamine/husk-web/pull/15) 중 버그 발견으로 인한 수정

## Problem Solving

<!-- 해결 방법 -->
- 대상 브랜치 수정 (develop -> main)
- ssh 접속 방식 수정 (password 사용 -> key 사용)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
미처 확인하지 못해서 workflow fail이 발생했네요...ㅎㅎ 죄송합니다.