### PR TITLE
Fix(HK-78): Docker 멀티 스테이지 빌드 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,4 +59,4 @@ jobs:
             sudo docker system prune -af
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker pull teamdopamine/husk-web:latest
-            sudo docker run -d -p 80:80 --name husk-web teamdopamine/husk-web:latest
+            sudo docker run -d -p 80:3000 teamdopamine/husk-web:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -795,10 +796,18 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2081,6 +2090,18 @@
         "core-js-compat": "^3.38.1",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -9066,6 +9087,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
       "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [이전 PR](https://github.com/team-dopamine/husk-web/pull/16) 참고
- 이전 PR의 Dockerfile을 통한 `docker run` 명령어 시 EC2 인스턴스(t2.micro)가 다운되는 현상이 발생하였음
  - 임의의 인스턴스(t2.medium)에서 실행할 경우 정상적으로 실행되는 것을 확인
  - 이를 통해 보다 경량의 도커 컨테이너가 필요하다고 판단하였음

## Problem Solving

- 멀티 스테이지 빌드 적용 (약 87% 절감)
  | 적용 전 | 적용 후 |
  | ------ | ------ |
  | ![image](https://github.com/user-attachments/assets/b58e436a-66b7-4526-ba15-ac37d21eb7ba) | ![image](https://github.com/user-attachments/assets/1d81d6ff-9722-44f1-9793-8eaa13c92b1a) |
    - node 이미지 수정 (경량의 slim 이미지 사용)
    - 기존의 더 많은 레이어들과 불필요한 빌드 도구들 포함하는 빌드 방식에서 필수적인 런타임 환경만 포함하도록 수정하였음 (빌드 도구와 소스 코드가 최종 이미지에서 제외)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- X