### PR TITLE
Fix(HK-78): docker 컨테이너 실행 시 컨테이너명 명시

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,9 +54,9 @@ jobs:
           username: ${{ secrets.SERVER_USERNAME }}
           key: ${{ secrets.SERVER_KEY }}
           script: |
-            sudo docker stop husk-web
-            sudo docker rm husk-web
+            sudo docker stop husk-web || true
+            sudo docker rm husk-web || true
             sudo docker system prune -af
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker pull teamdopamine/husk-web:latest
-            sudo docker run -d -p 80:3000 teamdopamine/husk-web:latest
+            sudo docker run -d --name husk-web -p 80:3000 teamdopamine/husk-web:latest


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [이전 PR 참고](https://github.com/team-dopamine/husk-web/pull/18)
- 기존 deploy workflow에서 컨테이너명을 명시하지 않았음
    - 이로 인해 기존 웹 서비스가 종료되지 않아 포트 충돌로 인해 새로운 버전의 서비스가 배포되지 않는 상황 발생

## Problem Solving

<!-- 해결 방법 -->
- deploy workflow의 `docker run` 구문에서 컨테이너 실행 시 컨테이너명 명시

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- X