### PR TITLE
Feature(HK-91): 회원가입 API 연결

### DIFF
--- a/src/api/sign-up/index.tsx
+++ b/src/api/sign-up/index.tsx
@@ -1,0 +1,40 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface RentalRequestData {
+  email: string;
+  password: string;
+}
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const postSignUp = async (data: RentalRequestData): Promise<void> => {
+  try {
+    const email = sessionStorage.getItem('email');
+    const password = sessionStorage.getItem('password');
+
+    const response = await api.post(
+      'auth/sign-up',
+      { email, password },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    alert(response.data.message);
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '오류가 발생했습니다.';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default postSignUp;

--- a/src/api/sign-up/index.tsx
+++ b/src/api/sign-up/index.tsx
@@ -1,5 +1,6 @@
 import api from 'api/axios';
 import { AxiosError } from 'axios';
+import { useLocation } from 'react-router-dom';
 
 interface RentalRequestData {
   email: string;
@@ -12,12 +13,12 @@ interface ErrorResponse {
 
 const postSignUp = async (data: RentalRequestData): Promise<void> => {
   try {
-    const email = sessionStorage.getItem('email');
-    const password = sessionStorage.getItem('password');
-
     const response = await api.post(
       'auth/sign-up',
-      { email, password },
+      {
+        email: data.email,
+        password: data.password,
+      },
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/sign-up/email-verify/index.tsx
+++ b/src/components/sign-up/email-verify/index.tsx
@@ -96,7 +96,9 @@ const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
+
     onInputChange('', '');
+    sessionStorage.setItem('email', e.target.value);
   };
 
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/sign-up/email-verify/index.tsx
+++ b/src/components/sign-up/email-verify/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { EmailWrapper, FormContainer, Label, InputField, RequestCodeButton, VerifyWrapper, VerifyButton, Timer, EmailFieldWrapper, Message } from './index.style';
 import postSendCode from 'api/send-code';
-import postVerifyCode from 'api/verify-code'; // postVerifyCode 가져오기
+import postVerifyCode from 'api/verify-code';
 
 interface EmailVerifyProps {
   onInputChange: (email: string, code: string) => void;
@@ -18,17 +18,12 @@ const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
 
   useEffect(() => {
     const savedTimer = sessionStorage.getItem('timer');
-    const savedEmailDisabled = sessionStorage.getItem('emailDisabled');
-    const savedShowCodeVerify = sessionStorage.getItem('showCodeVerify');
 
     if (savedTimer && Number(savedTimer) > 0) {
       setTimer(Number(savedTimer));
     } else {
       setTimer(0);
     }
-
-    setEmailDisabled(savedEmailDisabled === 'true' && Number(savedTimer) > 0);
-    setShowCodeVerify(savedShowCodeVerify === 'true' && Number(savedTimer) > 0);
   }, []);
 
   useEffect(() => {
@@ -52,10 +47,6 @@ const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
       sessionStorage.clear();
     }
   }, [timer, showCodeVerify]);
-
-  useEffect(() => {
-    sessionStorage.setItem('showCodeVerify', showCodeVerify.toString());
-  }, [showCodeVerify]);
 
   const handleRequestCode = async () => {
     try {
@@ -98,7 +89,6 @@ const EmailVerify: React.FC<EmailVerifyProps> = ({ onInputChange }) => {
     setEmail(e.target.value);
 
     onInputChange('', '');
-    sessionStorage.setItem('email', e.target.value);
   };
 
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/sign-up/password-setting/index.tsx
+++ b/src/components/sign-up/password-setting/index.tsx
@@ -24,6 +24,23 @@ interface PasswordProps {
 const PasswordSetting: React.FC<PasswordProps> = ({ onInputChange }) => {
   const [state, setState] = useState(createInitialState);
 
+  React.useEffect(() => {
+    const savedPassword = localStorage.getItem('password') || '';
+    const savedPasswordVerify = localStorage.getItem('passwordVerify') || '';
+
+    setState((prev) => ({
+      ...prev,
+      inputs: {
+        password: savedPassword,
+        passwordVerify: savedPasswordVerify,
+      },
+      isValid: {
+        password: isValidPassword(savedPassword),
+        passwordVerify: savedPasswordVerify === savedPassword,
+      },
+    }));
+  }, []);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     setState((prev) => {
@@ -32,6 +49,11 @@ const PasswordSetting: React.FC<PasswordProps> = ({ onInputChange }) => {
         ...prev.isValid,
         [id]: id === 'password' ? isValidPassword(value) : value === updatedInputs.password,
       };
+
+      // 로컬 스토리지에 비밀번호와 확인 비밀번호 저장
+      sessionStorage.setItem('password', updatedInputs.password);
+      sessionStorage.setItem('passwordVerify', updatedInputs.passwordVerify);
+
       onInputChange(updatedInputs.password, updatedInputs.passwordVerify);
 
       return { ...prev, inputs: updatedInputs, isValid: updatedIsValid };

--- a/src/components/sign-up/password-setting/index.tsx
+++ b/src/components/sign-up/password-setting/index.tsx
@@ -24,23 +24,6 @@ interface PasswordProps {
 const PasswordSetting: React.FC<PasswordProps> = ({ onInputChange }) => {
   const [state, setState] = useState(createInitialState);
 
-  React.useEffect(() => {
-    const savedPassword = localStorage.getItem('password') || '';
-    const savedPasswordVerify = localStorage.getItem('passwordVerify') || '';
-
-    setState((prev) => ({
-      ...prev,
-      inputs: {
-        password: savedPassword,
-        passwordVerify: savedPasswordVerify,
-      },
-      isValid: {
-        password: isValidPassword(savedPassword),
-        passwordVerify: savedPasswordVerify === savedPassword,
-      },
-    }));
-  }, []);
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     setState((prev) => {
@@ -49,10 +32,6 @@ const PasswordSetting: React.FC<PasswordProps> = ({ onInputChange }) => {
         ...prev.isValid,
         [id]: id === 'password' ? isValidPassword(value) : value === updatedInputs.password,
       };
-
-      // 로컬 스토리지에 비밀번호와 확인 비밀번호 저장
-      sessionStorage.setItem('password', updatedInputs.password);
-      sessionStorage.setItem('passwordVerify', updatedInputs.passwordVerify);
 
       onInputChange(updatedInputs.password, updatedInputs.passwordVerify);
 

--- a/src/pages/sign-up/content/index.tsx
+++ b/src/pages/sign-up/content/index.tsx
@@ -19,7 +19,7 @@ const Content = () => {
   };
   const handleNextClick = () => {
     if (isVerified) {
-      navigate('/password');
+      navigate('/password', { state: { email } });
     }
   };
 

--- a/src/pages/sign-up/password/password-content/index.tsx
+++ b/src/pages/sign-up/password/password-content/index.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { Container, ContentWrapper, Title, PreviousButton, NextButton, ButtonGroup } from './index.style';
 import PasswordSetting from '@components/sign-up/password-setting';
+import postSignUp from 'api/sign-up';
 
 const PasswordContent = () => {
   const [password, setPassword] = useState('');
   const [passwordVerify, setPasswordVerify] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleInputChange = (password: string, passwordVerify: string) => {
     setPassword(password);
@@ -12,6 +14,22 @@ const PasswordContent = () => {
   };
 
   const isPasswordMismatch = password.trim() === '' || passwordVerify.trim() === '' || password !== passwordVerify;
+
+  const handleNextClick = async () => {
+    if (isPasswordMismatch) return;
+
+    setIsSubmitting(true);
+    try {
+      await postSignUp({
+        email: 'data',
+        password,
+      });
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'An unexpected error occurred.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <Container>
@@ -22,8 +40,8 @@ const PasswordContent = () => {
           <PreviousButton type="primary" href="/sign-up">
             Previous
           </PreviousButton>
-          <NextButton type="submit" disabled={isPasswordMismatch}>
-            Next
+          <NextButton type="button" onClick={handleNextClick} disabled={isPasswordMismatch || isSubmitting}>
+            {isSubmitting ? 'Submitting...' : 'Next'}
           </NextButton>
         </ButtonGroup>
       </ContentWrapper>

--- a/src/pages/sign-up/password/password-content/index.tsx
+++ b/src/pages/sign-up/password/password-content/index.tsx
@@ -2,11 +2,15 @@ import { useState } from 'react';
 import { Container, ContentWrapper, Title, PreviousButton, NextButton, ButtonGroup } from './index.style';
 import PasswordSetting from '@components/sign-up/password-setting';
 import postSignUp from 'api/sign-up';
+import { useLocation } from 'react-router-dom';
 
 const PasswordContent = () => {
   const [password, setPassword] = useState('');
   const [passwordVerify, setPasswordVerify] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const location = useLocation();
+  const email = location.state?.email || '';
 
   const handleInputChange = (password: string, passwordVerify: string) => {
     setPassword(password);
@@ -21,7 +25,7 @@ const PasswordContent = () => {
     setIsSubmitting(true);
     try {
       await postSignUp({
-        email: 'data',
+        email,
         password,
       });
     } catch (error) {


### PR DESCRIPTION
## Motivation

- [HK-91](https://team-dopamine.atlassian.net/browse/HK-91?atlOrigin=eyJpIjoiMzQ4MzAyY2JkMmZjNDZiM2IzYTU2OGUwNmQyNTg0N2UiLCJwIjoiaiJ9) 참고
- 사용자로부터 입력받은 `email` 및 `password`를 통해 회원가입 하기 위한 API 연결

## Problem Solving

- 회원가입 api 호출 로직 구현(95eaed29ba3e689563f2480b0e28460f78e961d3)
- `/sign-up` 페이지에서 사용자로부터 입력 받은 `email`을 **navigate**를 통해 `/password` 페이지로 이동 시 함께 전달(9376b53dadeb7f49ba8dad0c18cefc88795211eb)
- `/password` 페이지에서 사용자로부터 입력 받은 `password`는 `email`과 함께 서버로 바로 POST

## To Reviewer

- email과 password를 `sessionStorage`로 저장하였으나, 보안 이슈를 비롯한 문제로 수정함


[HK-91]: https://team-dopamine.atlassian.net/browse/HK-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ