### PR TITLE
Feature(HK-94): 서비스 사용자 이용 약관 조회 API 연동

### DIFF
--- a/src/api/read-terms/index.tsx
+++ b/src/api/read-terms/index.tsx
@@ -1,0 +1,24 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface ErrorResponse {
+  message: string;
+}
+
+const getTermsOfService = async (): Promise<string> => {
+  try {
+    const response = await api.get('auth/terms-of-service');
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '오류가 발생했습니다.';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default getTermsOfService;

--- a/src/pages/sign-in/content/index.tsx
+++ b/src/pages/sign-in/content/index.tsx
@@ -12,7 +12,7 @@ const Content = () => {
         </ButtonGroup>
         <SignUpWrapper>
           <SignUpText>
-            계정이 없으신가요? <SignUpLink href="/sign-up">Sign up</SignUpLink>
+            계정이 없으신가요? <SignUpLink href="/read-terms">Sign up</SignUpLink>
           </SignUpText>
         </SignUpWrapper>
       </ContentWrapper>

--- a/src/pages/sign-up/read-terms/read-terms-content/index.style.tsx
+++ b/src/pages/sign-up/read-terms/read-terms-content/index.style.tsx
@@ -9,6 +9,7 @@ const ButtonStyle = styled(Button)`
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  text-decoration: none;
 `;
 
 export const HiddenCheckbox = styled.input`

--- a/src/pages/sign-up/read-terms/read-terms-content/index.tsx
+++ b/src/pages/sign-up/read-terms/read-terms-content/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Label,
   HiddenCheckbox,
@@ -14,9 +14,26 @@ import {
   AgreementCheckboxWrapper,
   AgreementText,
 } from './index.style';
+import getTermsOfService from 'api/read-terms';
 
 const ReadTermsContent = () => {
   const [isChecked, setIsChecked] = useState(false);
+  const [termsContent, setTermsContent] = useState('약관을 불러오는 중입니다...');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTerms = async () => {
+      try {
+        const terms = await getTermsOfService();
+        console.log('약관 내용:', terms);
+        setTermsContent(terms);
+      } catch (err) {
+        setError('약관을 불러오는 중 오류가 발생했습니다.');
+      }
+    };
+
+    fetchTerms();
+  }, []);
 
   return (
     <Container>
@@ -24,7 +41,7 @@ const ReadTermsContent = () => {
         <Title>Sign Up</Title>
         <TermsWrapper>
           <Label>이용약관</Label>
-          <TermsTextarea readOnly value="약관 내용" />
+          <TermsTextarea readOnly value={error || termsContent} />
           <AgreementCheckboxWrapper>
             <AgreementText>상기 내용에 동의합니다.</AgreementText>
             <HiddenCheckbox type="checkbox" id="customCheckbox" checked={isChecked} onChange={(e) => setIsChecked(e.target.checked)} />
@@ -32,10 +49,10 @@ const ReadTermsContent = () => {
           </AgreementCheckboxWrapper>
         </TermsWrapper>
         <ButtonGroup>
-          <PreviousButton type="primary" href="/sign-up">
+          <PreviousButton type="primary" href="/sign-in">
             Previous
           </PreviousButton>
-          <NextButton type="primary" disabled={!isChecked}>
+          <NextButton type="primary" disabled={!isChecked} href="/sign-up">
             Next
           </NextButton>
         </ButtonGroup>


### PR DESCRIPTION
## Motivation

- [HK-94](https://team-dopamine.atlassian.net/browse/HK-94?atlOrigin=eyJpIjoiZTMwYzcxYTBjNGU5NDA3N2I5OWIxYWU1MWZkYmMzNGEiLCJwIjoiaiJ9) 참고
- 회원가입 전 사용자에게 서비스 이용 약관을 공지하고 동의를 받기 위함

## Problem Solving

<img width="556" alt="스크린샷 2025-01-23 오후 7 04 09" src="https://github.com/user-attachments/assets/d83aa4cc-882c-436a-a80f-1a3bd5502fbb" />

- 서비스 이용 약관 api 호출 로직 구현(3ed124c3f43c8df75e1143e8f4a01e63ccedb7e7)
- 서비스 이용 약관 api 연동(9198902d5dcab362488eaf7b284c731f8f34e193)
     - 약관 동의를 반드시 해야 `Next` 버튼을 활성화, 이메일 유효성 검사 페이지로 넘어가도록 구현



## To Reviewer

- `이메일 검증` -> `비밀번호 설정` -> `약관동의` 순서에서 `약관동의` -> `이메일 검증` -> `비밀번호 설정` 로 변경


[HK-94]: https://team-dopamine.atlassian.net/browse/HK-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ