### PR TITLE
Feature(HK-103): 일반 로그인 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SignUp from '@pages/sign-up';
 import ReadTerms from '@pages/sign-up/content/read-terms';
 import Password from '@pages/sign-up/content/password';
 import Frame from '@components/frame';
+import AuthSignIn from '@pages/sign-in/sign-in-email';
 
 const App: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ const App: React.FC = () => {
         <Route path="/" element={<Frame />}>
           <Route index element={<Main />} />
           <Route path="sign-in" element={<SignIn />} />
+          <Route path="auth-sign-in" element={<AuthSignIn />} />
           <Route path="sign-up" element={<SignUp />} />
           <Route path="password" element={<Password />} />
           <Route path="read-terms" element={<ReadTerms />} />

--- a/src/pages/sign-in/content/index.tsx
+++ b/src/pages/sign-in/content/index.tsx
@@ -1,14 +1,23 @@
+import { useNavigate } from 'react-router-dom';
 import { ButtonGroup, Container, ContentWrapper, OAuthButton, SignUpLink, SignUpText, SignUpWrapper, Title } from './index.style';
 
 const Content = () => {
+  const navigate = useNavigate();
+
+  const handleOAuthSignIn = (provider: string) => {
+    if (provider === 'email') {
+      navigate('/auth-sign-in');
+    }
+  };
+
   return (
     <Container>
       <ContentWrapper>
         <Title>Sign In</Title>
         <ButtonGroup>
-          <OAuthButton>Continue with Google</OAuthButton>
-          <OAuthButton>Continue with GitHub</OAuthButton>
-          <OAuthButton>Continue with Email</OAuthButton>
+          <OAuthButton onClick={() => handleOAuthSignIn('google')}>Continue with Google</OAuthButton>
+          <OAuthButton onClick={() => handleOAuthSignIn('github')}>Continue with GitHub</OAuthButton>
+          <OAuthButton onClick={() => handleOAuthSignIn('email')}>Continue with Email</OAuthButton>
         </ButtonGroup>
         <SignUpWrapper>
           <SignUpText>

--- a/src/pages/sign-in/sign-in-email/content/index.style.tsx
+++ b/src/pages/sign-in/sign-in-email/content/index.style.tsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+import { Button, Input } from 'antd';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  height: calc(100vh - 300px);
+  flex: 1;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 400px;
+  width: 100%;
+  text-align: left;
+`;
+
+export const Title = styled.h1`
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 48px;
+  align-items: center;
+`;
+
+export const Label = styled.label`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  display: flex;
+
+  margin-bottom: 4px;
+`;
+export const LoginButton = styled(Button)`
+  width: 100%;
+  max-width: 492px;
+  height: 48px;
+  border-radius: 8px !important;
+  display: flex;
+  margin-top: 40px;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  text-decoration: none;
+
+  ${({ disabled }) =>
+    disabled &&
+    `
+    pointer-events: none;
+  `}
+
+  color: white !important;
+  background-color: black;
+  text-decoration: none;
+
+  &:hover {
+    background-color: gray !important;
+    color: white !important;
+    border: none;
+  }
+`;
+
+export const InputField = styled(Input)`
+  width: 100%;
+  max-width: 492px;
+  height: 36px;
+  border-radius: 6px;
+  padding: 8px 12px 8px 12px;
+  margin-bottom: 5px;
+
+  &:focus,
+  &:hover {
+    border: 1px solid gray !important;
+  }
+  &:disabled {
+    border: 1px solid lightgray;
+    &:hover {
+      border: 1px solid lightgray !important;
+    }
+  }
+`;

--- a/src/pages/sign-in/sign-in-email/content/index.tsx
+++ b/src/pages/sign-in/sign-in-email/content/index.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { Container, ContentWrapper, Title, InputField, LoginButton, Label } from '@pages/sign-in/sign-in-email/content/index.style';
+
+const SigninContent: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    console.log('Email:', email, 'Password:', password);
+  };
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Title>Sign In</Title>
+        <Label style={{ alignSelf: 'flex-start' }}>Email</Label>
+        <InputField type="email" placeholder="Enter your email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+
+        <Label style={{ alignSelf: 'flex-start' }}>Password</Label>
+        <InputField type="password" placeholder="Enter your password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+
+        <LoginButton onClick={handleLogin}>Login</LoginButton>
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default SigninContent;

--- a/src/pages/sign-in/sign-in-email/index.tsx
+++ b/src/pages/sign-in/sign-in-email/index.tsx
@@ -1,0 +1,11 @@
+import Content from './content';
+
+const AuthSignIn = () => {
+  return (
+    <>
+      <Content />
+    </>
+  );
+};
+
+export default AuthSignIn;


### PR DESCRIPTION
## Motivation

- [HK-103](https://team-dopamine.atlassian.net/browse/HK-103?atlOrigin=eyJpIjoiMTk1NjE0NDI0MzkzNGRhNmE4ZGE0N2U2MTQxNjA5MGEiLCJwIjoiaiJ9) 참고
- 사용자가 일반 회원가입을 통해 생성한 계정으로 로그인 할 수 있는 페이지

## Problem Solving

- `email`, `password` 입력필드 구현 (771bcd234b5bd96bc8d24414babf287db4775d25)
- `/sign-in` 의 `Continue with Email` 클릭 시 해당 페이지로 이동 (974515cd74411e1cf1bfbcea71eceb918084c5d9)
- `/auth-sign-in` 으로 일반 로그인 경로 추가(497489c464a1644d2df72f0f1853ccaf96788645)

## To Reviewer
- Amplify 통해 확인 가능합니다!
  

[HK-103]: https://team-dopamine.atlassian.net/browse/HK-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

