### PR TITLE
Feature(HK-93): GitHub 로그인 API 구현

### DIFF
--- a/src/api/sign-in/github/index.tsx
+++ b/src/api/sign-in/github/index.tsx
@@ -1,0 +1,40 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface ErrorResponse {
+  message: string;
+}
+
+interface JwtTokenDto {
+  grantType: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface GithubAuthResponse {
+  headers: Record<string, unknown>;
+  body: {
+    message: string;
+    jwtTokenDto: JwtTokenDto;
+  };
+  statusCode: string;
+  statusCodeValue: number;
+}
+
+const getGithub = async (code: string | null): Promise<GithubAuthResponse> => {
+  try {
+    const response = await api.get<GithubAuthResponse>(`/auth/sign-in?type=github&code=${code}`);
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '오류가 발생했습니다.';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default getGithub;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,9 +6,9 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
+  <>
     <App />
-  </React.StrictMode>
+  </>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/sign-in/content/index.tsx
+++ b/src/pages/sign-in/content/index.tsx
@@ -2,6 +2,8 @@ import { useGoogleLogin } from '@react-oauth/google';
 import { useNavigate } from 'react-router-dom';
 import { ButtonGroup, Container, ContentWrapper, OAuthButton, SignUpLink, SignUpText, SignUpWrapper, Title } from './index.style';
 
+const GITHUB_CLIENT_ID = process.env.REACT_APP_GITHUB_CLIENT_ID;
+const GITHUB_REDIRECT_URI = process.env.REACT_APP_GITHUB_REDIRECT_URI;
 const Content = () => {
   const navigate = useNavigate();
 
@@ -11,11 +13,21 @@ const Content = () => {
     redirect_uri: process.env.REACT_APP_REDIRECT_URI || '',
   });
 
+  const githubLogin = () => {
+    if (!GITHUB_CLIENT_ID || !GITHUB_REDIRECT_URI) {
+      console.error('GitHub OAuth 설정이 올바르지 않습니다. .env 파일을 확인하세요.');
+      return;
+    }
+    const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${GITHUB_REDIRECT_URI}&scope=user:email`;
+    window.location.href = githubAuthUrl;
+  };
   const handleOAuthSignIn = (provider: string) => {
     if (provider === 'email') {
       navigate('/auth-sign-in');
     } else if (provider === 'google') {
       googleLogin();
+    } else if (provider === 'github') {
+      githubLogin();
     }
   };
 

--- a/src/pages/sign-in/index.tsx
+++ b/src/pages/sign-in/index.tsx
@@ -1,13 +1,17 @@
 import { useSearchParams } from 'react-router-dom';
 import Content from './content';
 import GoogleCallback from './sign-in-google';
+import GithubCallback from './sign-in-github';
 
 const SignIn = () => {
   const [searchParams] = useSearchParams();
   const type = searchParams.get('type');
   console.log(type);
 
-  return type === 'google' ? <GoogleCallback /> : <Content />;
+  if (type === 'google') return <GoogleCallback />;
+  if (type === 'github') return <GithubCallback />;
+
+  return <Content />;
 };
 
 export default SignIn;

--- a/src/pages/sign-in/sign-in-github/index.tsx
+++ b/src/pages/sign-in/sign-in-github/index.tsx
@@ -1,0 +1,40 @@
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useContext, useEffect, useState } from 'react';
+import getGithub from 'api/sign-in/github';
+import { AuthContext } from 'api/context/auth-context';
+
+const Github = () => {
+  const [searchParams] = useSearchParams();
+  const [githubStatus, setGithubStatus] = useState<number | null>(null);
+  const { login } = useContext(AuthContext)!;
+  const navigate = useNavigate();
+
+  const code = searchParams.get('code');
+  console.log('Github OAuth Code:', code);
+
+  useEffect(() => {
+    const fetchGithubAuth = async () => {
+      try {
+        const response = await getGithub(code);
+        const status = response.statusCodeValue;
+        setGithubStatus(status);
+        if (status == 200) {
+          if (response.body.jwtTokenDto.accessToken) {
+            login(response.body.jwtTokenDto.accessToken);
+            navigate('/');
+          }
+        } else if (status == 400) {
+          navigate('/sign-in');
+        }
+      } catch (err) {
+        console.error('Github 로그인 오류:', err);
+      }
+    };
+
+    fetchGithubAuth();
+  }, [code, navigate]);
+
+  return <p>Github 로그인 처리 중...</p>;
+};
+
+export default Github;


### PR DESCRIPTION
## Motivation

- [HK-93](https://team-dopamine.atlassian.net/browse/HK-93?atlOrigin=eyJpIjoiOWExM2E3NGY3N2RlNGU1Mzk0N2UzMWE1ZjU1ZDNkNzkiLCJwIjoiaiJ9) 참고
- 깃허브 계정을 통해 HUSK 서비스에 로그인하고자 함

## Problem Solving

- 깃허브 로그인 API 호출 로직 구현 (21adf9d8690f474de67f4d93a45923e7c1e7c059)
- 깃허브 로그인 API 호출 (b60fe762bb82d69c41217af0942a32c431e8d0dd)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

- API가 두번씩 호출되는 오류가 발생하여 index.tsx의 `<React.StrictMode>` 삭제하였습니다

[HK-93]: https://team-dopamine.atlassian.net/browse/HK-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ