### PR TITLE
Fix(HK-92): 구글 OAuth status값 받아오기 수정

### DIFF
--- a/src/api/sign-in/github/index.tsx
+++ b/src/api/sign-in/github/index.tsx
@@ -6,8 +6,8 @@ interface ErrorResponse {
 }
 
 interface JwtTokenDto {
-  grantType: string;
   accessToken: string;
+  grantType: string;
   refreshToken: string;
 }
 

--- a/src/api/sign-in/google/index.tsx
+++ b/src/api/sign-in/google/index.tsx
@@ -5,7 +5,23 @@ interface ErrorResponse {
   message: string;
 }
 
-const getGoogle = async (code: string | null): Promise<number> => {
+interface JwtTokenDto {
+  accessToken: string;
+  grantType: string;
+  refreshToken: string;
+}
+
+interface GoogleAuthResponse {
+  headers: Record<string, unknown>;
+  body: {
+    message: string;
+    jwtTokenDto: JwtTokenDto;
+  };
+  statusCode: string;
+  statusCodeValue: number;
+}
+
+const getGoogle = async (code: string | null): Promise<GoogleAuthResponse> => {
   try {
     const response = await api.get(`/auth/sign-in?type=google&code=${code}`);
     return response.data;

--- a/src/pages/sign-in/index.tsx
+++ b/src/pages/sign-in/index.tsx
@@ -6,7 +6,6 @@ import GithubCallback from './sign-in-github';
 const SignIn = () => {
   const [searchParams] = useSearchParams();
   const type = searchParams.get('type');
-  console.log(type);
 
   if (type === 'google') return <GoogleCallback />;
   if (type === 'github') return <GithubCallback />;

--- a/src/pages/sign-in/sign-in-google/index.tsx
+++ b/src/pages/sign-in/sign-in-google/index.tsx
@@ -1,24 +1,27 @@
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from 'api/context/auth-context';
 import getGoogle from 'api/sign-in/google';
 
 const Google = () => {
   const [searchParams] = useSearchParams();
   const [googleStatus, setGoogleStatus] = useState<number | null>(null);
+  const { login } = useContext(AuthContext)!;
   const navigate = useNavigate();
 
   const code = searchParams.get('code');
-  console.log('Google OAuth Code:', code);
 
   useEffect(() => {
     const fetchGoogleAuth = async () => {
       try {
-        const status = await getGoogle(code);
-        console.log('서버 응답 상태 코드:', status);
-        console.log(googleStatus);
+        const response = await getGoogle(code);
+        const status = response.statusCodeValue;
         setGoogleStatus(status);
         if (status == 200) {
-          navigate('/');
+          if (response.body.jwtTokenDto.accessToken) {
+            login(response.body.jwtTokenDto.accessToken);
+            navigate('/');
+          }
         } else if (status == 400) {
           navigate('/sign-in');
         }
@@ -28,7 +31,7 @@ const Google = () => {
     };
 
     fetchGoogleAuth();
-  }, [navigate]);
+  }, [code, navigate]);
 
   return <p>Google 로그인 처리 중...</p>;
 };


### PR DESCRIPTION
## Motivation

- [HK-92](https://team-dopamine.atlassian.net/browse/HK-92) 참고

## Problem Solving

- 구글 로그인 API 응답 부분 수정 (cf0fb98142faae0a2bf192407fbcb9a04b1d0874)

## To Reviewer

- 기존에는 응답 값 자체를 받아와서 오류가 생긴 거 같습니다. 따라서 response.statusCodeValue로 접근하여 status값을 받아오도록 수정했습니다.


[HK-92]: https://team-dopamine.atlassian.net/browse/HK-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ