### PR TITLE
Feature(HK-98): 로그아웃 API 연결

### DIFF
--- a/src/api/axios.tsx
+++ b/src/api/axios.tsx
@@ -11,8 +11,6 @@ const api = axios.create({
 
 api.interceptors.request.use(
   (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
-    console.log('요청 인터셉터 실행');
-
     const accessToken = localStorage.getItem('accessToken');
 
     if (accessToken) {

--- a/src/api/context/auth-context/index.tsx
+++ b/src/api/context/auth-context/index.tsx
@@ -2,8 +2,10 @@ import { createContext } from 'react';
 
 interface AuthContextType {
   accessToken: string | null;
+  refreshToken: string | null;
   isLoggedIn: boolean;
-  login: (token: string) => void;
+  login: (token: string, refreshToken: string) => void;
+  logout: (token: string, refreshToken: string) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/api/context/auth-provider/index.tsx
+++ b/src/api/context/auth-provider/index.tsx
@@ -1,19 +1,43 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { AuthContext } from 'api/context/auth-context';
-import { getStoredToken, saveToken } from 'api/context/auth-util';
+import { getStoredRefreshToken, getStoredToken, removeToken, saveRefreshToken, saveToken } from 'api/context/auth-util';
+import postSignOut from 'api/sign-out';
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+
   useEffect(() => {
     const storedToken = getStoredToken();
+    const storedRefreshToken = getStoredRefreshToken();
 
     if (storedToken) setAccessToken(storedToken);
+    if (storedRefreshToken) setRefreshToken(storedRefreshToken);
   }, []);
 
-  const login = useCallback((token: string) => {
+  const login = useCallback((token: string, refreshToken: string) => {
     setAccessToken(token);
+    setRefreshToken(refreshToken);
     saveToken(token);
+    saveRefreshToken(refreshToken);
   }, []);
 
-  return <AuthContext.Provider value={{ accessToken, isLoggedIn: !!accessToken, login }}>{children}</AuthContext.Provider>;
+  const logout = useCallback(async () => {
+    if (!accessToken || !refreshToken) {
+      console.error('로그아웃 실패: 토큰이 없습니다.');
+      return;
+    }
+
+    try {
+      await postSignOut({ accessToken, refreshToken });
+
+      setAccessToken(null);
+      setRefreshToken(null);
+      removeToken();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
+  }, [accessToken, refreshToken]);
+
+  return <AuthContext.Provider value={{ accessToken, refreshToken, isLoggedIn: !!accessToken, login, logout }}>{children}</AuthContext.Provider>;
 };

--- a/src/api/context/auth-util/index.tsx
+++ b/src/api/context/auth-util/index.tsx
@@ -7,6 +7,30 @@ export const getStoredToken = () => {
     return null;
   }
 };
+
+export const getStoredRefreshToken = () => {
+  try {
+    return localStorage.getItem('refreshToken');
+  } catch (error) {
+    console.error('로컬 스토리지에서 리프레시 토큰 읽는 중', error);
+    localStorage.removeItem('refreshToken');
+    return null;
+  }
+};
 export const saveToken = (token: string) => {
   localStorage.setItem('accessToken', token);
+};
+
+export const saveRefreshToken = (refreshtoken: string) => {
+  localStorage.setItem('refreshToken', refreshtoken);
+};
+
+export const removeToken = () => {
+  try {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    console.log('로컬 스토리지에서 토큰 삭제 완료.');
+  } catch (error) {
+    console.error('로컬 스토리지에서 토큰 삭제 중 오류 발생:', error);
+  }
 };

--- a/src/api/sign-out/index.tsx
+++ b/src/api/sign-out/index.tsx
@@ -1,0 +1,40 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface RequestData {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const postSignOut = async (data: RequestData): Promise<void> => {
+  try {
+    const response = await api.post(
+      'auth/sign-out',
+      {
+        refreshToken: `Bearer ${data.refreshToken}`,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${data.accessToken}`,
+        },
+      }
+    );
+    alert(response.data.message);
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '로그아웃에 실패했습니다';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default postSignOut;

--- a/src/components/frame/index.tsx
+++ b/src/components/frame/index.tsx
@@ -16,35 +16,16 @@ const Frame = () => {
     setIsLoggedIn(storedLoginState);
   }, []);
 
-  useEffect(() => {
-    const handleStorageChange = () => {
-      const updatedLoginState = localStorage.getItem('isLoggedIn') === 'true';
-      setIsLoggedIn(updatedLoginState);
-    };
-
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
-
   const handleLoginSuccess = () => {
     localStorage.setItem('isLoggedIn', 'true');
     setIsLoggedIn(true);
     navigate('/');
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('isLoggedIn');
-    setIsLoggedIn(false);
-    navigate('/');
-  };
-  console.log('Frame - handleLoginSuccess:', { handleLoginSuccess });
   return (
     <>
       <Layout>
-        <Header isLoggedIn={isLoggedIn} onLogout={handleLogout} />
+        <Header />
         <Outlet context={{ handleLoginSuccess }} />
         <Footer />
       </Layout>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,28 +1,41 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { HeaderWrapper, LogoWrapper, LogoImg, Logo, LoginButton } from './index.style';
+import postSignOut from 'api/sign-out';
+import { AuthContext } from 'api/context/auth-context';
 
 interface HeaderProps {
   logoHref?: string;
-  loginButtonHref?: string;
-  loginButtonText?: string;
-  isLoggedIn?: boolean;
-  onLogout?: () => void;
+  goToLoginPage?: string;
 }
 
-const Header: React.FC<HeaderProps> = ({ logoHref = '/', loginButtonHref = '/sign-in', loginButtonText = 'Login', isLoggedIn, onLogout }) => {
+const Header: React.FC<HeaderProps> = ({ logoHref = '/', goToLoginPage = '/sign-in' }) => {
+  const { isLoggedIn, logout, accessToken, refreshToken } = useContext(AuthContext)!;
+
+  const handleLogout = async () => {
+    if (!accessToken || !refreshToken) {
+      console.error('로그아웃 실패: 토큰이 없습니다.');
+      return;
+    }
+    try {
+      await logout(accessToken, refreshToken);
+    } catch (error) {
+      console.error('로그아웃 오류:', error);
+    }
+  };
   return (
     <HeaderWrapper>
       <LogoWrapper>
         <LogoImg />
         <Logo href={logoHref}>Husk</Logo>
       </LogoWrapper>
+
       {isLoggedIn ? (
-        <LoginButton type="primary" onClick={onLogout}>
+        <LoginButton type="primary" onClick={handleLogout}>
           Logout
         </LoginButton>
       ) : (
-        <LoginButton type="primary" href={loginButtonHref}>
-          {loginButtonText}
+        <LoginButton type="primary" href={goToLoginPage}>
+          Login
         </LoginButton>
       )}
     </HeaderWrapper>

--- a/src/pages/sign-in/sign-in-email/content/index.tsx
+++ b/src/pages/sign-in/sign-in-email/content/index.tsx
@@ -16,8 +16,11 @@ const SigninContent: React.FC = () => {
     try {
       setLoading(true);
       const response = await postSignIn({ email, password });
-      if (response.jwtTokenDto.accessToken) {
-        login(response.jwtTokenDto.accessToken);
+
+      if (response.jwtTokenDto.accessToken && response.jwtTokenDto.refreshToken) {
+        const { accessToken, refreshToken } = response.jwtTokenDto;
+
+        login(accessToken, refreshToken);
         navigate('/');
       }
     } catch (error) {

--- a/src/pages/sign-in/sign-in-github/index.tsx
+++ b/src/pages/sign-in/sign-in-github/index.tsx
@@ -18,16 +18,19 @@ const Github = () => {
         const response = await getGithub(code);
         const status = response.statusCodeValue;
         setGithubStatus(status);
-        if (status == 200) {
-          if (response.body.jwtTokenDto.accessToken) {
-            login(response.body.jwtTokenDto.accessToken);
+
+        if (status === 200) {
+          const { accessToken, refreshToken } = response.body.jwtTokenDto;
+          if (accessToken && refreshToken) {
+            login(accessToken, refreshToken);
             navigate('/');
           }
-        } else if (status == 400) {
+        } else if (status === 400) {
           navigate('/sign-in');
         }
       } catch (err) {
         console.error('Github 로그인 오류:', err);
+        navigate('/sign-in');
       }
     };
 

--- a/src/pages/sign-in/sign-in-google/index.tsx
+++ b/src/pages/sign-in/sign-in-google/index.tsx
@@ -17,9 +17,10 @@ const Google = () => {
         const response = await getGoogle(code);
         const status = response.statusCodeValue;
         setGoogleStatus(status);
-        if (status == 200) {
-          if (response.body.jwtTokenDto.accessToken) {
-            login(response.body.jwtTokenDto.accessToken);
+        if (status === 200) {
+          const { accessToken, refreshToken } = response.body.jwtTokenDto;
+          if (accessToken && refreshToken) {
+            login(accessToken, refreshToken);
             navigate('/');
           }
         } else if (status == 400) {


### PR DESCRIPTION
## Motivation

- [HK-98](https://team-dopamine.atlassian.net/browse/HK-98?atlOrigin=eyJpIjoiNzg0Njg5OTZmODRkNDczNWExYzZkODExZDdkYTA3NTkiLCJwIjoiaiJ9) 참고
- 사용자가 로그아웃을 할 수 있도록 API 구현

## Problem Solving

- refreshToken을 저장하도록 context api에 구현(54728da6d0845f942b1fb50c3ccb2351b41c8cdd)
- accessToken을 헤더에, refreshToken을 바디에 담아서 서버로 POST (15793a9e1214d5c166bf8e321b07d10654f2a680)
- 로그아웃 api 연동 구현(9d097dbd2aaee5e4bdf820f6f1ff5cad101d78cc)


## To Reviewer

- 로그인 상태 시 LoginButton의 Text -> Logout,  Logout 호출 시 -> Login으로 변경하도록 구현
- 그 외 불필요 로직 및 코드 삭제(278f14b138a29fa1b15e63745718ce66340f1a88), (14effd231fd362bb0883dfd469cf959febfef919)


[HK-98]: https://team-dopamine.atlassian.net/browse/HK-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ