### PR TITLE
Feature(HK-100): 서비스 계정 탈퇴 API 연동 구현

### DIFF
--- a/src/api/context/auth-context/index.tsx
+++ b/src/api/context/auth-context/index.tsx
@@ -6,6 +6,7 @@ interface AuthContextType {
   isLoggedIn: boolean;
   login: (token: string, refreshToken: string) => void;
   logout: (token: string, refreshToken: string) => void;
+  withdraw: (token: string) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/api/context/auth-provider/index.tsx
+++ b/src/api/context/auth-provider/index.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { AuthContext } from 'api/context/auth-context';
 import { getStoredRefreshToken, getStoredToken, removeToken, saveRefreshToken, saveToken } from 'api/context/auth-util';
 import postSignOut from 'api/sign-out';
+import patchWithdraw from 'api/withdraw';
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
@@ -39,5 +40,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [accessToken, refreshToken]);
 
-  return <AuthContext.Provider value={{ accessToken, refreshToken, isLoggedIn: !!accessToken, login, logout }}>{children}</AuthContext.Provider>;
+  const withdraw = useCallback(async () => {
+    if (!accessToken) {
+      console.error('로그아웃 실패: 토큰이 없습니다.');
+      return;
+    }
+    try {
+      await patchWithdraw({ accessToken });
+
+      setAccessToken(null);
+      setRefreshToken(null);
+      removeToken();
+    } catch (error) {}
+  }, [accessToken]);
+
+  return <AuthContext.Provider value={{ accessToken, refreshToken, isLoggedIn: !!accessToken, login, logout, withdraw }}>{children}</AuthContext.Provider>;
 };

--- a/src/api/withdraw/index.tsx
+++ b/src/api/withdraw/index.tsx
@@ -1,0 +1,37 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface ResponseData {
+  accessToken: string;
+}
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const patchWithdraw = async (data: ResponseData): Promise<void> => {
+  try {
+    const response = await api.patch(
+      'auth/withdraw',
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${data.accessToken}`,
+        },
+      }
+    );
+    alert(response.data.message);
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '회원탈퇴에 실패했습니다';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default patchWithdraw;

--- a/src/components/header/index.style.tsx
+++ b/src/components/header/index.style.tsx
@@ -56,3 +56,19 @@ export const LoginButton = styled(Button)`
     border-color: gray !important;
   }
 `;
+
+export const WithdrawButton = styled(Button)`
+  background-color: black !important;
+  opacity: 30% !important;
+  text-decoration: none;
+  margin-left: 10px;
+  &:hover {
+    background-color: white !important;
+    color: gray !important;
+    font-weight: 700;
+    border-color: gray !important;
+  }
+`;
+
+export const AuthBox = styled.div`
+s`;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -28,6 +28,7 @@ const Header: React.FC<HeaderProps> = ({ logoHref = '/', goToLoginPage = '/sign-
       console.error('회원탈퇴 실패: 토큰이 없습니다.');
       return;
     }
+    // TODO: 확인 메시지 추가 예정
     try {
       await withdraw(accessToken);
       handleLogout();

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
-import { HeaderWrapper, LogoWrapper, LogoImg, Logo, LoginButton } from './index.style';
-import postSignOut from 'api/sign-out';
+import { HeaderWrapper, LogoWrapper, LogoImg, Logo, LoginButton, WithdrawButton, AuthBox } from './index.style';
 import { AuthContext } from 'api/context/auth-context';
 
 interface HeaderProps {
@@ -9,7 +8,7 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ logoHref = '/', goToLoginPage = '/sign-in' }) => {
-  const { isLoggedIn, logout, accessToken, refreshToken } = useContext(AuthContext)!;
+  const { isLoggedIn, logout, withdraw, accessToken, refreshToken } = useContext(AuthContext)!;
 
   const handleLogout = async () => {
     if (!accessToken || !refreshToken) {
@@ -22,6 +21,20 @@ const Header: React.FC<HeaderProps> = ({ logoHref = '/', goToLoginPage = '/sign-
       console.error('로그아웃 오류:', error);
     }
   };
+
+  const handleWithdraw = async () => {
+    if (!isLoggedIn) return;
+    if (!accessToken) {
+      console.error('회원탈퇴 실패: 토큰이 없습니다.');
+      return;
+    }
+    try {
+      await withdraw(accessToken);
+      handleLogout();
+    } catch (error) {
+      console.error('회원탈퇴 오류:', error);
+    }
+  };
   return (
     <HeaderWrapper>
       <LogoWrapper>
@@ -29,15 +42,21 @@ const Header: React.FC<HeaderProps> = ({ logoHref = '/', goToLoginPage = '/sign-
         <Logo href={logoHref}>Husk</Logo>
       </LogoWrapper>
 
-      {isLoggedIn ? (
-        <LoginButton type="primary" onClick={handleLogout}>
-          Logout
-        </LoginButton>
-      ) : (
-        <LoginButton type="primary" href={goToLoginPage}>
-          Login
-        </LoginButton>
-      )}
+      <AuthBox>
+        {isLoggedIn ? (
+          <LoginButton type="primary" onClick={handleLogout}>
+            Logout
+          </LoginButton>
+        ) : (
+          <LoginButton type="primary" href={goToLoginPage}>
+            Login
+          </LoginButton>
+        )}
+        {/* TODO: 추후 위치 변경예정 */}
+        <WithdrawButton type="primary" onClick={handleWithdraw}>
+          탈퇴하기
+        </WithdrawButton>
+      </AuthBox>
     </HeaderWrapper>
   );
 };


### PR DESCRIPTION
## Motivation

- [HK-100](https://team-dopamine.atlassian.net/jira/software/projects/HK/boards/2/backlog?selectedIssue=HK-14&atlOrigin=eyJpIjoiYmUzMDU4N2E4ZWIwNDZiZGFiYmIwYWM2ZWIzODM3MDMiLCJwIjoiaiJ9) 참고
- 사용자가 서비스를 탈퇴할 수 있도록 하기 위함

## Problem Solving
- 서비스 계정 탈퇴 api 호출 로직 구현(21b142b89bb39aa36b0569d5c6b3ba86ab64468c)
- 탈퇴하기 버튼 클릭 시 서비스 계정 탈퇴 api 호출 (206cb0f139a9c8c904be4689ff3030cf20880afd)

## To Reviewer


- 우선 임의로 로그인 옆에 탈퇴하기 버튼 만들어두었음(9bac2034a18fc2bbd62b8c1661c26b0f1f02dc55)
- 추후 위치 수정 예정 및 탈퇴 확인 알림 (`ex`회원탈퇴 하시겠습니까?) 메시지 추가 예정이라 **TODO:** 로 표시


[HK-100]: https://team-dopamine.atlassian.net/browse/HK-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ