### PR TITLE
Fix(HK-135): 도커 실행 시 포트 매핑 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,4 +59,4 @@ jobs:
             sudo docker system prune -af
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker pull teamdopamine/husk-web:latest
-            sudo docker run -d --name husk-web -p 8080:80 teamdopamine/husk-web:latest
+            sudo docker run -d --name husk-web -p 3000:80 teamdopamine/husk-web:latest


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 이전 PR 참고(https://github.com/team-dopamine/husk-web/pull/45)
- PR merge 후 CD 실패. 
  - `docker run` 명령어 실행 시 포트 수정 필요

## Problem Solving

<!-- 해결 방법 -->
- `8080:80` 에서 `3000:80`으로 수정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 죄송합니다..😢 