### PR TITLE
Feature(HK-138): 로그인 상태에 따른 시작하기 버튼 라우팅

### DIFF
--- a/src/pages/main/content/index.tsx
+++ b/src/pages/main/content/index.tsx
@@ -1,52 +1,67 @@
 import { Banner, Title, Description, ButtonContainer, FunctionButton, StartButton, MainContent, ContentContainer, MainTitle, MainDescription, ContentImage, TextContainer } from './index.style';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../api/context/use-auth';
 
-const Content = () => (
-  <>
-    <Banner>
-      <Title>HUSK: Help Use Shell Kindly</Title>
-      <Description>HUSK는 웹 기반 터미널 서비스입니다. 사용자들은 터미널을 통해 다양한 기능을 사용할 수 있습니다.</Description>
-      <ButtonContainer>
-        <FunctionButton type="primary">기능 소개</FunctionButton>
-        <StartButton type="primary" href="/dashboard">
-          시작하기
-        </StartButton>
-      </ButtonContainer>
-    </Banner>
+const Content = () => {
+  const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
 
-    <MainContent>
-      <ContentContainer>
-        <ContentImage />
-        <TextContainer>
-          <MainTitle>SSH Connection</MainTitle>
-          <MainDescription>SSH 연결을 통해 원격 서버에 접속할 수 있습니다.</MainDescription>
-        </TextContainer>
-      </ContentContainer>
+  const handleStartClick = () => {
+    if (isLoggedIn) {
+      navigate('/dashboard');
+    } else {
+      navigate('/sign-in');
+    }
+  };
 
-      <ContentContainer>
-        <ContentImage />
-        <TextContainer>
-          <MainTitle>Multiple Window</MainTitle>
-          <MainDescription>여러 개의 터미널 창을 열어 작업을 병렬로 진행할 수 있습니다.</MainDescription>
-        </TextContainer>
-      </ContentContainer>
+  return (
+    <>
+      <Banner>
+        <Title>HUSK: Help Use Shell Kindly</Title>
+        <Description>HUSK는 웹 기반 터미널 서비스입니다. 사용자들은 터미널을 통해 다양한 기능을 사용할 수 있습니다.</Description>
+        <ButtonContainer>
+          <FunctionButton type="primary">기능 소개</FunctionButton>
+          <StartButton type="primary" onClick={handleStartClick}>
+            시작하기
+          </StartButton>
+        </ButtonContainer>
+      </Banner>
 
-      <ContentContainer>
-        <ContentImage />
-        <TextContainer>
-          <MainTitle>Chatbot Support</MainTitle>
-          <MainDescription>챗봇을 통해 터미널 사용법을 학습하고, 명령어를 추천받을 수 있습니다.</MainDescription>
-        </TextContainer>
-      </ContentContainer>
+      <MainContent>
+        <ContentContainer>
+          <ContentImage />
+          <TextContainer>
+            <MainTitle>SSH Connection</MainTitle>
+            <MainDescription>SSH 연결을 통해 원격 서버에 접속할 수 있습니다.</MainDescription>
+          </TextContainer>
+        </ContentContainer>
 
-      <ContentContainer>
-        <ContentImage />
-        <TextContainer>
-          <MainTitle>PC File System</MainTitle>
-          <MainDescription>사용자의 PC 파일 시스템을 터미널에서 사용할 수 있습니다.</MainDescription>
-        </TextContainer>
-      </ContentContainer>
-    </MainContent>
-  </>
-);
+        <ContentContainer>
+          <ContentImage />
+          <TextContainer>
+            <MainTitle>Multiple Window</MainTitle>
+            <MainDescription>여러 개의 터미널 창을 열어 작업을 병렬로 진행할 수 있습니다.</MainDescription>
+          </TextContainer>
+        </ContentContainer>
+
+        <ContentContainer>
+          <ContentImage />
+          <TextContainer>
+            <MainTitle>Chatbot Support</MainTitle>
+            <MainDescription>챗봇을 통해 터미널 사용법을 학습하고, 명령어를 추천받을 수 있습니다.</MainDescription>
+          </TextContainer>
+        </ContentContainer>
+
+        <ContentContainer>
+          <ContentImage />
+          <TextContainer>
+            <MainTitle>PC File System</MainTitle>
+            <MainDescription>사용자의 PC 파일 시스템을 터미널에서 사용할 수 있습니다.</MainDescription>
+          </TextContainer>
+        </ContentContainer>
+      </MainContent>
+    </>
+  );
+};
 
 export default Content;


### PR DESCRIPTION
## Motivation

- [(HK-138)](https://team-dopamine.atlassian.net/browse/HK-138) 참고
- 로그인 상태에 따른 홈 화면 '시작하기' 버튼 라우팅
   - 로그인 상태: /dashboard 페이지로 이동
   - 로그아웃 상태: /sign-in 페이지로 이동 

## Problem Solving

- useAuth 훅을 통해 로그인 상태 가져와 조건 라우팅 (caeadef6f51bbaad10ac9d05d36c719d95e1faa3)

## To Reviewer

아주 조금 변경되어 따로 이슈나 브랜치를 만들지 않고 작업했습니다^^
