### PR TITLE
Feature(HK-125): 키체인 수정 API 연동 및 수정 모달창 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^5.5.1",
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@react-oauth/google": "^0.12.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -3213,6 +3216,48 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^5.5.1",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@react-oauth/google": "^0.12.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/api/keychains/keychain-update/index.tsx
+++ b/src/api/keychains/keychain-update/index.tsx
@@ -1,0 +1,38 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface RequestData {
+  name: string;
+  content: string;
+  id: number;
+}
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const patchKeyChainUpdate = async (data: RequestData): Promise<void> => {
+  try {
+    const response = await api.patch(
+      `keychains`,
+      { id: data.id, name: data.name, content: data.content },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    alert(response.data.message);
+  } catch (error: unknown) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = (error.response.data as ErrorResponse)?.message || '키체인 수정에 실패했습니다';
+      throw new Error(errorMessage);
+    } else if (error instanceof AxiosError && error.request) {
+      throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+    } else {
+      throw new Error('알 수 없는 오류가 발생했습니다.');
+    }
+  }
+};
+
+export default patchKeyChainUpdate;

--- a/src/components/dashboard/button/index.tsx
+++ b/src/components/dashboard/button/index.tsx
@@ -1,59 +1,20 @@
-import postKeychain from 'api/keychains/keychain-register';
 import { Container, ActionButton, Divider } from './index.style';
-import { getStoredToken } from 'api/context/auth-util';
-import patchKeyChainDelete from 'api/keychains/keychain-delete';
+// import patchKeyChainDelete from 'api/keychains/keychain-delete';
+// import patchKeyChainUpdate from 'api/keychains/keychain-update';
 
 type ButtonGroupProps = {
   inputValues: string[];
   id?: number;
+  onSave: () => void;
+  onDelete: () => void;
 };
 
-const ButtonGroup: React.FC<ButtonGroupProps> = ({ inputValues, id }) => {
-  const handleSave = async () => {
-    const accessToken = getStoredToken();
-
-    if (!accessToken) {
-      alert('로그인이 필요합니다.');
-      return;
-    }
-
-    try {
-      const trimmedValues = inputValues.map((value) => value.trim());
-
-      if (trimmedValues.some((value) => value === '')) {
-        alert('모든 필드를 입력하세요.');
-        return;
-      }
-
-      await postKeychain({
-        name: inputValues[0],
-        content: inputValues[1],
-        accessToken,
-      });
-    } catch (error) {
-      console.error('Error posting data:', error);
-      alert(error instanceof Error ? error.message : '데이터 저장에 실패했습니다.');
-    }
-  };
-
-  const handleDelete = async () => {
-    if (!id) {
-      alert('삭제할 키체인을 찾을 수 없습니다.');
-      return;
-    }
-    try {
-      await patchKeyChainDelete(id);
-    } catch (error) {
-      console.error('Error posting data:', error);
-      alert(error instanceof Error ? error.message : '데이터 저장에 실패했습니다.');
-    }
-  };
-
+const ButtonGroup: React.FC<ButtonGroupProps> = ({ inputValues, id, onSave, onDelete }) => {
   return (
     <Container>
-      <ActionButton onClick={handleSave}>Save</ActionButton>
+      <ActionButton onClick={onSave}>update</ActionButton>
       <Divider />
-      <ActionButton onClick={handleDelete}>Delete</ActionButton>
+      <ActionButton onClick={onDelete}>Delete</ActionButton>
     </Container>
   );
 };

--- a/src/components/dashboard/button/index.tsx
+++ b/src/components/dashboard/button/index.tsx
@@ -1,6 +1,4 @@
 import { Container, ActionButton, Divider } from './index.style';
-// import patchKeyChainDelete from 'api/keychains/keychain-delete';
-// import patchKeyChainUpdate from 'api/keychains/keychain-update';
 
 type ButtonGroupProps = {
   inputValues: string[];
@@ -9,7 +7,7 @@ type ButtonGroupProps = {
   onDelete: () => void;
 };
 
-const ButtonGroup: React.FC<ButtonGroupProps> = ({ inputValues, id, onSave, onDelete }) => {
+const ButtonGroup: React.FC<ButtonGroupProps> = ({ onSave, onDelete }) => {
   return (
     <Container>
       <ActionButton onClick={onSave}>update</ActionButton>

--- a/src/components/dashboard/button/saveButton/index.style.tsx
+++ b/src/components/dashboard/button/saveButton/index.style.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  width: 272px;
+  height: 40px;
+  align-items: center;
+  background-color: #222;
+  border-radius: 20px;
+  padding: 10px 20px;
+`;
+
+export const ActionButton = styled.button`
+  width: 272px;
+  height: 40px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 5px 10px;
+  outline: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+`;

--- a/src/components/dashboard/button/saveButton/index.tsx
+++ b/src/components/dashboard/button/saveButton/index.tsx
@@ -1,0 +1,44 @@
+import postKeychain from 'api/keychains/keychain-register';
+import { Container, ActionButton } from './index.style';
+import { getStoredToken } from 'api/context/auth-util';
+
+type SaveButtonGroupProps = {
+  inputValues: string[];
+};
+
+const SaveButton: React.FC<SaveButtonGroupProps> = ({ inputValues }) => {
+  const handleSave = async () => {
+    const accessToken = getStoredToken();
+
+    if (!accessToken) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+
+    try {
+      const trimmedValues = inputValues.map((value) => value.trim());
+
+      if (trimmedValues.some((value) => value === '')) {
+        alert('모든 필드를 입력하세요.');
+        return;
+      }
+
+      await postKeychain({
+        name: inputValues[0],
+        content: inputValues[1],
+        accessToken,
+      });
+    } catch (error) {
+      console.error('Error posting data:', error);
+      alert(error instanceof Error ? error.message : '데이터 저장에 실패했습니다.');
+    }
+  };
+
+  return (
+    <Container>
+      <ActionButton onClick={handleSave}>Register</ActionButton>
+    </Container>
+  );
+};
+
+export default SaveButton;

--- a/src/components/dashboard/cards/keychain-card/index.style.tsx
+++ b/src/components/dashboard/cards/keychain-card/index.style.tsx
@@ -13,10 +13,6 @@ export const Container = styled(Card)`
   display: flex;
   flex-direction: column;
   transition: transform 0.2s;
-
-  &:hover {
-    transform: scale(1.02);
-  }
 `;
 
 export const ContentWrapper = styled.div`
@@ -47,4 +43,7 @@ export const MoreButton = styled(MoreVertical)`
   position: relative;
   top: -25px;
   left: 20px;
+  &:hover {
+    transform: scale(1.07);
+  }
 `;

--- a/src/components/dashboard/cards/keychain-card/index.tsx
+++ b/src/components/dashboard/cards/keychain-card/index.tsx
@@ -1,24 +1,45 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Container, Label, Title, Content, ContentWrapper, MoreButton } from './index.style';
+import KeychainReadModal from '@components/dashboard/modals/keychain-read-modal';
 
 type CardProps = {
   title?: string;
   label?: string;
   onClick?: () => void;
   className?: string;
+  id?: number;
 };
 
-const KeychainCard: React.FC<CardProps> = ({ title, label, onClick, className = '' }) => {
+const KeychainCard: React.FC<CardProps> = ({ title, label, className = ' ', id }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
   return (
-    <Container className={className} onClick={onClick}>
-      <ContentWrapper>
-        <Content>
-          {label && <Title>{label}</Title>}
-          {title && <Label>{title}</Label>}
-        </Content>
-        <MoreButton size={33} color="#333" />
-      </ContentWrapper>
-    </Container>
+    <>
+      <Container className={className}>
+        <ContentWrapper>
+          <Content>
+            {label && <Title>{label}</Title>}
+            {title && <Label>{title}</Label>}
+          </Content>
+          <MoreButton
+            size={33}
+            color="#333"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsModalOpen(true);
+            }}
+          />
+        </ContentWrapper>
+      </Container>{' '}
+      <KeychainReadModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        fields={[
+          { label: 'Name', placeholder: title || '데이터 없음' },
+          { label: 'Private Key (Contents)', placeholder: `*********` },
+        ]}
+        id={id}
+      />
+    </>
   );
 };
 

--- a/src/components/dashboard/modals/keychain-read-modal/handlers/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/handlers/index.tsx
@@ -1,0 +1,41 @@
+import patchKeyChainUpdate from 'api/keychains/keychain-update';
+import patchKeyChainDelete from 'api/keychains/keychain-delete';
+
+export const handleKeychainSave = async ({ id, inputValues, onClose, onSuccess }: { id?: number; inputValues: string[]; onClose: () => void; onSuccess?: () => void }) => {
+  if (!id) {
+    alert('수정할 키체인을 찾을 수 없습니다.');
+    return;
+  }
+
+  const [name, content] = inputValues.map((v) => v.trim());
+
+  if (!name || !content) {
+    alert('모든 필드를 입력하세요.');
+    return;
+  }
+
+  try {
+    await patchKeyChainUpdate({ id, name, content });
+    onClose();
+    onSuccess?.();
+  } catch (error) {
+    console.error(error);
+    alert(error instanceof Error ? error.message : '업데이트 실패');
+  }
+};
+
+export const handleKeychainDelete = async ({ id, onClose, onSuccess }: { id?: number; onClose: () => void; onSuccess?: () => void }) => {
+  if (!id) {
+    alert('삭제할 키체인을 찾을 수 없습니다.');
+    return;
+  }
+
+  try {
+    await patchKeyChainDelete(id);
+    onClose();
+    onSuccess?.();
+  } catch (error) {
+    console.error('삭제 오류:', error);
+    alert(error instanceof Error ? error.message : '삭제 실패');
+  }
+};

--- a/src/components/dashboard/modals/keychain-read-modal/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/index.tsx
@@ -1,27 +1,12 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
-import { Label, ModalContent, Overlay, InputContainer, InputWrapper, InputField, CloseButton } from './index.style';
+import { ModalContent, Overlay, CloseButton } from './index.style';
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
 import ButtonGroup from '../../button';
-import patchKeyChainDelete from 'api/keychains/keychain-delete';
-import patchKeyChainUpdate from 'api/keychains/keychain-update';
-
-const useModal = () => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const openModal = useCallback(() => setIsOpen(true), []);
-  const closeModal = useCallback(() => setIsOpen(false), []);
-
-  return { isOpen, openModal, closeModal };
-};
-
-interface ModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  fields: { label: string; placeholder: string }[];
-  id?: number;
-  onSuccess?: () => void;
-}
+import InputGroup from './inputGroup';
+import useModal from '../../../../hooks/useModal';
+import { ModalProps } from './types';
+import { handleKeychainDelete, handleKeychainSave } from './handlers';
 
 const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, onSuccess }) => {
   if (!isOpen) return null;
@@ -35,59 +20,17 @@ const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, 
       return newValues;
     });
   };
-  const handleSave = async () => {
-    if (!id) {
-      alert('수정할 키체인을 찾을 수 없습니다.');
-      return;
-    }
 
-    const [name, content] = inputValues.map((v) => v.trim());
+  const handleSave = () => handleKeychainSave({ id, inputValues, onClose, onSuccess });
+  const handleDelete = () => handleKeychainDelete({ id, onClose, onSuccess });
 
-    if (!name || !content) {
-      alert('모든 필드를 입력하세요.');
-      return;
-    }
-
-    try {
-      await patchKeyChainUpdate({ id, name, content });
-      onClose();
-      onSuccess?.();
-    } catch (error) {
-      console.error(error);
-      alert(error instanceof Error ? error.message : '업데이트 실패');
-    }
-  };
-
-  const handleDelete = async () => {
-    if (!id) {
-      alert('삭제할 키체인을 찾을 수 없습니다.');
-      return;
-    }
-
-    try {
-      await patchKeyChainDelete(id);
-      onClose();
-      onSuccess?.();
-    } catch (error) {
-      console.error('삭제 오류:', error);
-      alert(error instanceof Error ? error.message : '삭제 실패');
-    }
-  };
   return ReactDOM.createPortal(
     <Overlay onClick={onClose}>
       <ModalContent onClick={(e) => e.stopPropagation()} style={{ margin: '24px' }}>
         <CloseButton onClick={onClose}>
           <CloseIcon />
         </CloseButton>
-
-        <InputWrapper>
-          {fields.map((field, index) => (
-            <InputContainer key={index}>
-              <Label>{field.label}</Label>
-              <InputField placeholder={field.placeholder} value={inputValues[index]} onChange={(e) => handleInputChange(index, e.target.value)} />
-            </InputContainer>
-          ))}
-        </InputWrapper>
+        <InputGroup fields={fields} inputValues={inputValues} onChange={handleInputChange} />
         <ButtonGroup inputValues={inputValues} id={id} onSave={handleSave} onDelete={handleDelete} />
       </ModalContent>
     </Overlay>,

--- a/src/components/dashboard/modals/keychain-read-modal/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/index.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import { Label, ModalContent, Overlay, InputContainer, InputWrapper, InputField, CloseButton } from './index.style';
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
 import ButtonGroup from '../../button';
+import patchKeyChainDelete from 'api/keychains/keychain-delete';
+import patchKeyChainUpdate from 'api/keychains/keychain-update';
 
 const useModal = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -18,9 +20,10 @@ interface ModalProps {
   onClose: () => void;
   fields: { label: string; placeholder: string }[];
   id?: number;
+  onSuccess?: () => void;
 }
 
-const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id }) => {
+const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, onSuccess }) => {
   if (!isOpen) return null;
 
   const [inputValues, setInputValues] = useState<string[]>(fields.map((f) => f.placeholder));
@@ -32,7 +35,44 @@ const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id }
       return newValues;
     });
   };
+  const handleSave = async () => {
+    if (!id) {
+      alert('수정할 키체인을 찾을 수 없습니다.');
+      return;
+    }
 
+    const [name, content] = inputValues.map((v) => v.trim());
+
+    if (!name || !content) {
+      alert('모든 필드를 입력하세요.');
+      return;
+    }
+
+    try {
+      await patchKeyChainUpdate({ id, name, content });
+      onClose();
+      onSuccess?.();
+    } catch (error) {
+      console.error(error);
+      alert(error instanceof Error ? error.message : '업데이트 실패');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!id) {
+      alert('삭제할 키체인을 찾을 수 없습니다.');
+      return;
+    }
+
+    try {
+      await patchKeyChainDelete(id);
+      onClose();
+      onSuccess?.();
+    } catch (error) {
+      console.error('삭제 오류:', error);
+      alert(error instanceof Error ? error.message : '삭제 실패');
+    }
+  };
   return ReactDOM.createPortal(
     <Overlay onClick={onClose}>
       <ModalContent onClick={(e) => e.stopPropagation()} style={{ margin: '24px' }}>
@@ -44,11 +84,11 @@ const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id }
           {fields.map((field, index) => (
             <InputContainer key={index}>
               <Label>{field.label}</Label>
-              <InputField placeholder={field.placeholder} value={inputValues[index]} onChange={(e) => handleInputChange(index, e.target.value)} readOnly />
+              <InputField placeholder={field.placeholder} value={inputValues[index]} onChange={(e) => handleInputChange(index, e.target.value)} />
             </InputContainer>
           ))}
         </InputWrapper>
-        <ButtonGroup inputValues={inputValues} id={id} />
+        <ButtonGroup inputValues={inputValues} id={id} onSave={handleSave} onDelete={handleDelete} />
       </ModalContent>
     </Overlay>,
     document.body

--- a/src/components/dashboard/modals/keychain-read-modal/inputGroup/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/inputGroup/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { InputWrapper, InputContainer, Label, InputField } from '../index.style';
+
+interface Props {
+  fields: { label: string; placeholder: string }[];
+  inputValues: string[];
+  onChange: (index: number, value: string) => void;
+}
+
+const InputGroup: React.FC<Props> = ({ fields, inputValues, onChange }) => {
+  return (
+    <InputWrapper>
+      {fields.map((field, index) => (
+        <InputContainer key={index}>
+          <Label>{field.label}</Label>
+          <InputField placeholder={field.placeholder} value={inputValues[index]} onChange={(e) => onChange(index, e.target.value)} />
+        </InputContainer>
+      ))}
+    </InputWrapper>
+  );
+};
+
+export default InputGroup;

--- a/src/components/dashboard/modals/keychain-read-modal/types/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/types/index.tsx
@@ -1,0 +1,7 @@
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fields: { label: string; placeholder: string }[];
+  id?: number;
+  onSuccess?: () => void;
+}

--- a/src/components/dashboard/modals/register-modal/index.tsx
+++ b/src/components/dashboard/modals/register-modal/index.tsx
@@ -1,23 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Label, ModalContent, Overlay, ButtonWrapper, InputContainer, InputWrapper, InputField, CloseButton } from './index.style';
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
 import SaveButton from '@components/dashboard/button/saveButton';
-
-const useModal = () => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const openModal = useCallback(() => setIsOpen(true), []);
-  const closeModal = useCallback(() => setIsOpen(false), []);
-
-  return { isOpen, openModal, closeModal };
-};
-
-interface ModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  fields: { label: string; placeholder: string }[];
-}
+import useModal from '../../../../hooks/useModal';
+import { ModalProps } from './types';
 
 const RegisterModal: React.FC<ModalProps> = ({ isOpen, onClose, fields }) => {
   if (!isOpen) return null;

--- a/src/components/dashboard/modals/register-modal/index.tsx
+++ b/src/components/dashboard/modals/register-modal/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
-import ButtonGroup from '../../button';
 import { Label, ModalContent, Overlay, ButtonWrapper, InputContainer, InputWrapper, InputField, CloseButton } from './index.style';
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
+import SaveButton from '@components/dashboard/button/saveButton';
 
 const useModal = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -53,7 +53,7 @@ const RegisterModal: React.FC<ModalProps> = ({ isOpen, onClose, fields }) => {
         </InputWrapper>
 
         <ButtonWrapper>
-          <ButtonGroup inputValues={inputValues} />
+          <SaveButton inputValues={inputValues} />
         </ButtonWrapper>
       </ModalContent>
     </Overlay>,

--- a/src/components/dashboard/modals/register-modal/types/index.tsx
+++ b/src/components/dashboard/modals/register-modal/types/index.tsx
@@ -1,0 +1,5 @@
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fields: { label: string; placeholder: string }[];
+}

--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -1,0 +1,12 @@
+import { useCallback, useState } from 'react';
+
+const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = useCallback(() => setIsOpen(true), []);
+  const closeModal = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, openModal, closeModal };
+};
+
+export default useModal;


### PR DESCRIPTION
## Motivation

- [HK-125](https://team-dopamine.atlassian.net/browse/HK-125?atlOrigin=eyJpIjoiMGRiYzg3NWU4MzVlNDQwYjhmNTdiMGYzMGFhNjU4ZDMiLCJwIjoiaiJ9) 참고
- 사용자가 키체인 name 및 Private Key를 수정하기 위함

## Problem Solving

- 키체인 등록 모달창의 버튼 그룹 수정
- 케밥버튼 클릭 시 키체인 수정 및 삭제가 가능한 모달 열림
- 키체인 수정 api 연동

## To Reviewer

- font-awesome 라이브러리 설치했으나 타 브랜치에서 작업하기로 협의(004283954ff95757ed9431d375654cbfec9d0b4e)
- 버튼그룹 리팩토링하면서 삭제 호출 api도 같이 이관

### ♻️ 코드 리팩토링

- 핸들러 추가하여 api 호출 분리 ([6db79c9](https://github.com/team-dopamine/husk-web/pull/50/commits/6db79c969e83f6b61cdf7ed6a5e07ad91f608c1e))
- type 분리 ([d497551](https://github.com/team-dopamine/husk-web/pull/50/commits/d497551eab9de544efe3f71fcd0a115a949cac91))
- `useModal` 훅 분리 ([834ea8e](https://github.com/team-dopamine/husk-web/pull/50/commits/834ea8e7ceaad32b3794398ecd960b539ff78b4b))
- input 필드 분리 ([fa47bb8](https://github.com/team-dopamine/husk-web/pull/50/commits/fa47bb86ea8fb8e3e1075c21855a31c182041d0e))

[HK-125]: https://team-dopamine.atlassian.net/browse/HK-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ