### PR TITLE
Feature(HK-127): 키체인 복호화 API 연동 및 복호화 기능 추가

### DIFF
--- a/src/api/keychains/keychain-decrypt/index.tsx
+++ b/src/api/keychains/keychain-decrypt/index.tsx
@@ -1,0 +1,33 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+
+interface KeychainResponse {
+  seletedData: number;
+  name: string;
+  content: string;
+}
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const getKeychainDecrypt = async (seletedData: any): Promise<KeychainResponse> => {
+  try {
+    const response = await api.get(`keychains/${seletedData}/decrypt`, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        const errorMessage = (error.response.data as ErrorResponse)?.message || '저장에 실패했습니다';
+        throw new Error(errorMessage);
+      } else if (error.request) {
+        throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+      }
+    }
+    throw new Error('알 수 없는 오류가 발생했습니다.');
+  }
+};
+
+export default getKeychainDecrypt;

--- a/src/api/keychains/keychain-decrypt/index.tsx
+++ b/src/api/keychains/keychain-decrypt/index.tsx
@@ -11,7 +11,7 @@ interface ErrorResponse {
   message?: string;
 }
 
-const getKeychainDecrypt = async (seletedData: any): Promise<KeychainResponse> => {
+const getKeychainDecrypt = async (seletedData): Promise<KeychainResponse> => {
   try {
     const response = await api.get(`keychains/${seletedData}/decrypt`, {
       headers: { 'Content-Type': 'application/json' },

--- a/src/api/keychains/keychain-decrypt/index.tsx
+++ b/src/api/keychains/keychain-decrypt/index.tsx
@@ -11,7 +11,7 @@ interface ErrorResponse {
   message?: string;
 }
 
-const getKeychainDecrypt = async (seletedData): Promise<KeychainResponse> => {
+const getKeychainDecrypt = async (seletedData: number | undefined): Promise<KeychainResponse> => {
   try {
     const response = await api.get(`keychains/${seletedData}/decrypt`, {
       headers: { 'Content-Type': 'application/json' },

--- a/src/components/dashboard/button/index.style.tsx
+++ b/src/components/dashboard/button/index.style.tsx
@@ -9,6 +9,7 @@ export const Container = styled.div`
   background-color: #222;
   border-radius: 20px;
   padding: 10px 20px;
+  margin: auto;
 `;
 
 export const ButtonStyle = styled(Button)`

--- a/src/components/dashboard/button/index.tsx
+++ b/src/components/dashboard/button/index.tsx
@@ -10,7 +10,7 @@ type ButtonGroupProps = {
 const ButtonGroup: React.FC<ButtonGroupProps> = ({ onSave, onDelete }) => {
   return (
     <Container>
-      <ActionButton onClick={onSave}>update</ActionButton>
+      <ActionButton onClick={onSave}>Update</ActionButton>
       <Divider />
       <ActionButton onClick={onDelete}>Delete</ActionButton>
     </Container>

--- a/src/components/dashboard/cards/keychain-card/index.tsx
+++ b/src/components/dashboard/cards/keychain-card/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Container, Label, Title, Content, ContentWrapper, MoreButton } from './index.style';
 import KeychainReadModal from '@components/dashboard/modals/keychain-read-modal';
+import getKeychainDecrypt from 'api/keychains/keychain-decrypt';
 
 type CardProps = {
   title?: string;
@@ -12,6 +13,32 @@ type CardProps = {
 
 const KeychainCard: React.FC<CardProps> = ({ title, label, className = ' ', id }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [decryptedContent, setDecryptedContent] = useState('');
+
+  useEffect(() => {
+    const fetchDecryptedValue = async () => {
+      try {
+        const response = await getKeychainDecrypt(id);
+        setDecryptedContent(response.content);
+      } catch (error) {
+        console.error('복호화 실패:', error);
+      }
+    };
+
+    if (isModalOpen) {
+      fetchDecryptedValue();
+    }
+  }, [isModalOpen, id]);
+
+  const handleOpen = async () => {
+    try {
+      const response = await getKeychainDecrypt(id);
+      setDecryptedContent(response.content);
+      setIsModalOpen(true);
+    } catch (err) {
+      console.error('복호화 실패', err);
+    }
+  };
   return (
     <>
       <Container className={className}>
@@ -25,7 +52,7 @@ const KeychainCard: React.FC<CardProps> = ({ title, label, className = ' ', id }
             color="#333"
             onClick={(e) => {
               e.stopPropagation();
-              setIsModalOpen(true);
+              handleOpen();
             }}
           />
         </ContentWrapper>
@@ -34,8 +61,8 @@ const KeychainCard: React.FC<CardProps> = ({ title, label, className = ' ', id }
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         fields={[
-          { label: 'Name', placeholder: title || '데이터 없음' },
-          { label: 'Private Key (Contents)', placeholder: `*********` },
+          { label: 'Name', placeholder: title || '데이터 없음', type: 'text' },
+          { label: 'Private Key (Contents)', placeholder: decryptedContent || '********', type: 'password' },
         ]}
         id={id}
       />

--- a/src/components/dashboard/cards/register-card/index.style.tsx
+++ b/src/components/dashboard/cards/register-card/index.style.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Card } from 'antd';
 
 export const CardStyle = styled(Card).attrs({
-  bodyStyle: { padding: '0px' },
+  styles: { body: { padding: 0 } },
 })`
   display: flex;
   flex-direction: column;

--- a/src/components/dashboard/modals/keychain-read-modal/index.style.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/index.style.tsx
@@ -94,3 +94,11 @@ export const CloseButton = styled.button`
     opacity: 0.7;
   }
 `;
+
+export const KeychainCheckboxLabel = styled.label`
+  margin-bottom: 10px;
+`;
+
+export const KeychainCheckbox = styled.input`
+  margin-right: 8px;
+`;

--- a/src/components/dashboard/modals/keychain-read-modal/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/index.tsx
@@ -1,17 +1,21 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
-import { ModalContent, Overlay, CloseButton } from './index.style';
-import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
+import { ModalContent, Overlay, CloseButton, KeychainCheckboxLabel, KeychainCheckbox } from './index.style';
+import { ReactComponent as CloseIcon } from 'assets/CloseIcon.svg';
 import ButtonGroup from '../../button';
 import InputGroup from './inputGroup';
-import useModal from '../../../../hooks/useModal';
-import { ModalProps } from './types';
+import useModal from 'hooks/useModal';
+import { KeychainResponse, ModalProps } from './types';
 import { handleKeychainDelete, handleKeychainSave } from './handlers';
+import getKeychainDecrypt from 'api/keychains/keychain-decrypt';
 
 const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, onSuccess }) => {
   if (!isOpen) return null;
 
   const [inputValues, setInputValues] = useState<string[]>(fields.map((f) => f.placeholder));
+  const [showKeychain, setShowKeychain] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [decryptedValue, setDecryptedValue] = useState('');
 
   const handleInputChange = (index: number, value: string) => {
     setInputValues((prev) => {
@@ -19,6 +23,36 @@ const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, 
       newValues[index] = value;
       return newValues;
     });
+  };
+
+  const handleCheckboxChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    setShowKeychain(checked);
+
+    if (!id) {
+      console.error('선택된 ID가 없습니다.');
+      return;
+    }
+
+    if (checked) {
+      if (decryptedValue || isLoading) return;
+
+      try {
+        setIsLoading(true);
+        const response: KeychainResponse = await getKeychainDecrypt(id);
+        setDecryptedValue(response.content);
+
+        setInputValues((prev) => {
+          const newValues = [...prev];
+          newValues[1] = response.content;
+          return newValues;
+        });
+      } catch (error) {
+        console.error('키체인 데이터를 불러오는 중 오류 발생:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
   };
 
   const handleSave = () => handleKeychainSave({ id, inputValues, onClose, onSuccess });
@@ -30,7 +64,11 @@ const KeychainReadModal: React.FC<ModalProps> = ({ isOpen, onClose, fields, id, 
         <CloseButton onClick={onClose}>
           <CloseIcon />
         </CloseButton>
-        <InputGroup fields={fields} inputValues={inputValues} onChange={handleInputChange} />
+        <InputGroup fields={fields} inputValues={inputValues} onChange={handleInputChange} showKeychain={showKeychain} />
+        <KeychainCheckboxLabel>
+          <KeychainCheckbox type="checkbox" checked={showKeychain} onChange={handleCheckboxChange} disabled={isLoading} />
+          키체인 값 표시
+        </KeychainCheckboxLabel>
         <ButtonGroup inputValues={inputValues} id={id} onSave={handleSave} onDelete={handleDelete} />
       </ModalContent>
     </Overlay>,

--- a/src/components/dashboard/modals/keychain-read-modal/inputGroup/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/inputGroup/index.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { InputWrapper, InputContainer, Label, InputField } from '../index.style';
 
 interface Props {
-  fields: { label: string; placeholder: string }[];
+  fields: { label: string; placeholder: string; type?: string }[];
   inputValues: string[];
   onChange: (index: number, value: string) => void;
+  showKeychain?: boolean;
 }
 
-const InputGroup: React.FC<Props> = ({ fields, inputValues, onChange }) => {
+const InputGroup: React.FC<Props> = ({ fields, inputValues, onChange, showKeychain = false }) => {
   return (
     <InputWrapper>
       {fields.map((field, index) => (
         <InputContainer key={index}>
           <Label>{field.label}</Label>
-          <InputField placeholder={field.placeholder} value={inputValues[index]} onChange={(e) => onChange(index, e.target.value)} />
+          <InputField type={field.type === 'password' && showKeychain ? 'text' : field.type || 'text'} value={inputValues[index]} onChange={(e) => onChange(index, e.target.value)} />
         </InputContainer>
       ))}
     </InputWrapper>

--- a/src/components/dashboard/modals/keychain-read-modal/types/index.tsx
+++ b/src/components/dashboard/modals/keychain-read-modal/types/index.tsx
@@ -1,7 +1,11 @@
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
-  fields: { label: string; placeholder: string }[];
+  fields: { label: string; placeholder: string; type: string }[];
   id?: number;
   onSuccess?: () => void;
+}
+
+export interface KeychainResponse {
+  content: string;
 }

--- a/src/pages/keychain/index.tsx
+++ b/src/pages/keychain/index.tsx
@@ -42,6 +42,7 @@ const KeychainPage = () => {
       {responseData.map((item) => {
         return (
           <KeychainCard
+            key={item.id}
             id={item.id}
             title={`${item.name}`}
             label={`Type PEM`}
@@ -73,8 +74,12 @@ const KeychainPage = () => {
           onClose={() => setIsReadModalOpen(false)}
           onSuccess={fetchKeychain}
           fields={[
-            { label: 'Name', placeholder: selectedData.name },
-            { label: 'Private Key (Contents)', placeholder: selectedData.content },
+            { label: 'Name', placeholder: selectedData.name, type: 'text' },
+            {
+              label: 'Private Key (Contents)',
+              placeholder: selectedData.content,
+              type: 'password',
+            },
           ]}
           id={selectedData?.id}
         />


### PR DESCRIPTION
## Motivation

- [(HK-127)](https://team-dopamine.atlassian.net/browse/HK-127) 참고
- 사용자가 키체인 값을 복호화하여 보기 위함

## Problem Solving

-  ( Update | Delete ) 버튼 중앙 정렬 및 update → Update로 텍스트 수정 ( dd518093ec8d1d5156c7664971ca3c2cebdd3e99),(bcf3775cf7d4b6e019ff64a096c5bd390385f334)
- key 누락 및 deprecated bodyStyle 경고 해결 (2cbcef11177ceb18e879ab6872d2c57c3f4217f1)
- 키체인 복호화 API 함수 및 관련 타입 정의 추가 (b0a51caf2957f1b5aceeb6a513358175e10a5cea)
- 키체인 복호화 API 연동 및 복호화 기능 구현 (1e075903b9f4e184658e2e2de1c6bf3f4a499f17), (af9277ec657f3dd73226a1223a05c67bc26a401d), (36ecd6eab9b457b8ed0410b43deab3ca85df4aa2)

## To Reviewer

🔐 키체인 값 마스킹 처리 방식 변경

- 기존: 고정된 길이의 `*******` 형태로 가짜 마스킹 값 렌더링
- 문제: 암호화된 상태로 값을 수정하기 힘듦 
   - *******의 고정된 길이로 업데이트 시, 예: ******123 혹은 *******을 다 지운 상태로 값을 수정 
   - 마스킹된 값을 수정할 때도 내부 실제 값을 따로 추적해야 해서 구현 복잡도 ↑
- 개선 방식: type = 'password' 속성 사용 
   - 키체인 값 길이에 맞게 자연스럽게 처리됨
   - 값 추적이 쉬워져 onChange로 그대로 처리 가능

원래는 기존 방식대로 구현하려 했으나, 위와 같은 문제로 방식을 변경했습니다.
혹시 기존 방식으로 더 간단하게 구현할 수 있는 아이디어나 제가 놓친 부분이 있다면 말씀 부탁드립니다!
