### PR TITLE
Feature(HK-130): SSH 커넥션 조회 api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import TempUpdatePasswordConfirm from '@pages/temp-update-password/verify';
 import TempUpdatePasswordSetting from '@pages/temp-update-password/setting';
 import Dashboard from '@pages/dashboard';
 import KeychainPage from '@pages/keychain';
+import SshConnectionPage from '@pages/ssh-connection';
 
 const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID || '';
 
@@ -39,6 +40,7 @@ const App: React.FC = () => {
             <Route path="/dashboard" element={<DashboardFrame />}>
               <Route index element={<Dashboard />} />
               <Route path="keychain-page" element={<KeychainPage />} />
+              <Route path="sshConnection-page" element={<SshConnectionPage />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/src/api/ssh-connections/index.tsx
+++ b/src/api/ssh-connections/index.tsx
@@ -1,0 +1,41 @@
+import api from 'api/axios';
+import { AxiosError } from 'axios';
+import { getStoredToken } from 'api/context/auth-util';
+
+interface RequestData {
+  id: number;
+  name: string;
+  host: string;
+  port: string;
+  accessToken: string;
+}
+
+interface ErrorResponse {
+  message: string;
+}
+
+const getSshConnections = async (): Promise<RequestData[]> => {
+  const accessToken = getStoredToken();
+  try {
+    const response = await api.get<RequestData[]>('connections', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    console.log('🔍 response:', response);
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        const errorMessage = (error.response.data as ErrorResponse)?.message || '오류가 발생했습니다.';
+        throw new Error(errorMessage);
+      } else if (error.request) {
+        throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+      }
+    }
+    throw new Error('알 수 없는 오류가 발생했습니다.');
+  }
+};
+
+export default getSshConnections;

--- a/src/api/ssh-connections/index.tsx
+++ b/src/api/ssh-connections/index.tsx
@@ -9,10 +9,6 @@ export interface SshConnection {
   port: string;
 }
 
-interface RawResponseData extends SshConnection {
-  accessToken: string;
-}
-
 interface ErrorResponse {
   message: string;
 }
@@ -25,9 +21,14 @@ const getSshConnections = async (): Promise<SshConnection[]> => {
       Authorization: `Bearer ${token}`,
     };
 
-    const { data } = await api.get<RawResponseData[]>('/connections', { headers });
+    const { data } = await api.get<SshConnection[]>('/connections', { headers });
 
-    return data.map(({ id, name, host, port }) => ({ id, name, host, port }));
+    return data.map((item) => ({
+      id: item.id,
+      name: item.name,
+      host: item.host,
+      port: item.port,
+    }));
   } catch (error: unknown) {
     const err = error as AxiosError<ErrorResponse>;
 

--- a/src/components/dashboard/layout/dashboard-sidebar/index.tsx
+++ b/src/components/dashboard/layout/dashboard-sidebar/index.tsx
@@ -6,7 +6,7 @@ const Sidebar = () => {
 
   return (
     <SidebarWrapper>
-      <SidebarItem onClick={() => navigate('#')}>
+      <SidebarItem onClick={() => navigate('/dashboard/sshConnection-page')}>
         <ButtonImg>🚀</ButtonImg>SSH Connection
       </SidebarItem>
       <SidebarItem onClick={() => navigate('/dashboard/keychain-page')}>

--- a/src/pages/ssh-connection/index.style.tsx
+++ b/src/pages/ssh-connection/index.style.tsx
@@ -4,4 +4,6 @@ export const SshConnectionContainer = styled.div`
   display: flex;
   gap: 40px;
   flex-wrap: wrap;
+  margin-top: 176px;
+  margin-left: 280px;
 `;

--- a/src/pages/ssh-connection/index.style.tsx
+++ b/src/pages/ssh-connection/index.style.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const SshConnectionContainer = styled.div`
+  display: flex;
+  gap: 40px;
+  flex-wrap: wrap;
+`;

--- a/src/pages/ssh-connection/index.tsx
+++ b/src/pages/ssh-connection/index.tsx
@@ -1,34 +1,28 @@
-import getSshConnections from 'api/ssh-connections';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import getSshConnections, { SshConnection } from 'api/ssh-connections';
 import { SshConnectionContainer } from './index.style';
 import KeychainCard from '@components/dashboard/cards/keychain-card';
 
-interface SshResponse {
-  id: number;
-  name: string;
-  host: string;
-  port: string;
-}
-
 const SshConnectionPage = () => {
-  const [sshData, setSshData] = useState<SshResponse[]>([]);
-  const fetchSshConnections = useCallback(async () => {
-    try {
-      const response = await getSshConnections();
-      setSshData(response);
-    } catch (error) {
-      console.error('SSH 연결 목록을 불러오는 중 오류 발생: ', error);
-    }
-  }, []);
+  const [sshConnections, setSshConnections] = useState<SshConnection[]>([]);
 
   useEffect(() => {
-    fetchSshConnections();
-  }, [fetchSshConnections]);
+    const fetchData = async () => {
+      try {
+        const data = await getSshConnections();
+        setSshConnections(data);
+      } catch (error) {
+        console.error('SSH 연결 목록을 불러오는 중 오류 발생:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   return (
-    <SshConnectionContainer style={{ marginTop: '176px', marginLeft: '280px' }}>
-      {sshData.map((item) => (
-        <KeychainCard key={item.id} id={item.id} title={item.name} label={`${item.host}:${item.port}`} />
+    <SshConnectionContainer>
+      {sshConnections.map(({ id, name, host, port }) => (
+        <KeychainCard key={id} id={id} title={name} label={`${host}:${port}`} />
       ))}
     </SshConnectionContainer>
   );

--- a/src/pages/ssh-connection/index.tsx
+++ b/src/pages/ssh-connection/index.tsx
@@ -1,0 +1,37 @@
+import getSshConnections from 'api/ssh-connections';
+import { useCallback, useEffect, useState } from 'react';
+import { SshConnectionContainer } from './index.style';
+import KeychainCard from '@components/dashboard/cards/keychain-card';
+
+interface SshResponse {
+  id: number;
+  name: string;
+  host: string;
+  port: string;
+}
+
+const SshConnectionPage = () => {
+  const [sshData, setSshData] = useState<SshResponse[]>([]);
+  const fetchSshConnections = useCallback(async () => {
+    try {
+      const response = await getSshConnections();
+      setSshData(response);
+    } catch (error) {
+      console.error('SSH 연결 목록을 불러오는 중 오류 발생: ', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSshConnections();
+  }, [fetchSshConnections]);
+
+  return (
+    <SshConnectionContainer style={{ marginTop: '176px', marginLeft: '280px' }}>
+      {sshData.map((item) => (
+        <KeychainCard key={item.id} id={item.id} title={item.name} label={`${item.host}:${item.port}`} />
+      ))}
+    </SshConnectionContainer>
+  );
+};
+
+export default SshConnectionPage;


### PR DESCRIPTION
## Motivation

- [HK-130](https://team-dopamine.atlassian.net/browse/HK-122?atlOrigin=eyJpIjoiZWE1ODQwZGY2MmM3NGM0ZDgyNWViMjQ3NjIzZjVkNTgiLCJwIjoiaiJ9) 참고
- 사용자가 등록한 SSH 커넥션을 조회하여 확인하기 위함

## Problem Solving

- SSH 조회 api 연동 로직 구현(c38ab6c3de50020a6a6bf5e7a807e8ba505c0e91)
- SSH 커넥션 페이지 구현 (43ce18f70a641bf81128806b3d5d51ef5ac3693f)
- SSH 조회 api 연동 (43ce18f70a641bf81128806b3d5d51ef5ac3693f)
- 페이지 경로 설정 및 사이드 바 클릭 시 해당 경로 이동 (2f5bc469eb96156c378e90d811b17d931b2b8e22)

## To reviewer
- 공통 구조를 export 해서 사용할 수 있도록 리팩토링(64f29b298d2958ce8b1b80cbd96acdb147747994)
- 스타일 margin을 스타일 컴포넌트 파일로 이동 (a4909c3)


[HK-130]: https://team-dopamine.atlassian.net/browse/HK-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ