### PR TITLE
Feature(HK-144): SSH 커넥션 삭제 API 연동

### DIFF
--- a/src/api/ssh-connections/ssh-delete/index.tsx
+++ b/src/api/ssh-connections/ssh-delete/index.tsx
@@ -1,0 +1,28 @@
+import api from 'api/axios';
+
+import { isAxiosError } from 'axios';
+
+interface ErrorResponse {
+  message?: string;
+}
+
+const deleteSshConnection = async (id: number): Promise<void> => {
+  try {
+    const response = await api.delete(`connections/${id}`);
+
+    const message = typeof response.data?.message === 'string' ? response.data.message : '삭제가 완료되었습니다.';
+    alert(message);
+  } catch (error: unknown) {
+    if (isAxiosError(error)) {
+      if (error.response) {
+        const errorMessage = (error.response.data as ErrorResponse)?.message || '삭제에 실패했습니다.';
+        throw new Error(errorMessage);
+      } else if (error.request) {
+        throw new Error('네트워크 문제 또는 서버가 응답하지 않습니다.');
+      }
+    }
+    throw new Error('알 수 없는 오류가 발생했습니다.');
+  }
+};
+
+export default deleteSshConnection;

--- a/src/components/dashboard/cards/sshConnection-card/index.tsx
+++ b/src/components/dashboard/cards/sshConnection-card/index.tsx
@@ -47,7 +47,7 @@ const SshConnectionCard: React.FC<Props> = ({ id, title, label, onClick, classNa
         onClose={() => setIsModalOpen(false)}
         inputValues={[title, label]}
         onSave={() => {
-          // TODO: 실제 키체인 수정 로직 작성
+          // TODO: 추후 SSH 수정 로직 작성
           console.log('Saved:', id);
         }}
       />

--- a/src/components/dashboard/cards/sshConnection-card/index.tsx
+++ b/src/components/dashboard/cards/sshConnection-card/index.tsx
@@ -42,14 +42,14 @@ const SshConnectionCard: React.FC<Props> = ({ id, title, label, onClick, classNa
       </Container>
       {/* TODO: 추후 api 연결 시 수정 */}
       <SshConnectionReadModal
+        id={id}
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        currentPage="ssh-connection"
-        fields={[
-          { label: 'Connection Name', placeholder: title },
-          { label: 'Host:Port', placeholder: label },
-          { label: 'ID', placeholder: id.toString() },
-        ]}
+        inputValues={[title, label]}
+        onSave={() => {
+          // TODO: 실제 키체인 수정 로직 작성
+          console.log('Saved:', id);
+        }}
       />
     </>
   );

--- a/src/components/dashboard/modals/register-modal/index.tsx
+++ b/src/components/dashboard/modals/register-modal/index.tsx
@@ -4,9 +4,9 @@ import { Label, ModalContent, Overlay, ButtonWrapper, InputContainer, InputWrapp
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
 import SaveButton from '@components/dashboard/button/saveButton';
 import useModal from '../../../../hooks/useModal';
-import { ModalProps } from './types';
+import { RegisterModalProps } from '../types';
 
-const RegisterModal: React.FC<ModalProps> = ({ isOpen, onClose, currentPage, fields }) => {
+const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, currentPage, fields }) => {
   if (!isOpen) return null;
 
   const [inputValues, setInputValues] = useState<string[]>(fields.map(() => ''));
@@ -49,5 +49,4 @@ const RegisterModal: React.FC<ModalProps> = ({ isOpen, onClose, currentPage, fie
 };
 
 export { useModal };
-export type { ModalProps };
 export default RegisterModal;

--- a/src/components/dashboard/modals/register-modal/types/index.tsx
+++ b/src/components/dashboard/modals/register-modal/types/index.tsx
@@ -1,6 +1,0 @@
-export interface ModalProps {
-  isOpen: boolean;
-  currentPage: string;
-  onClose: () => void;
-  fields: { label: string; placeholder: string }[];
-}

--- a/src/components/dashboard/modals/sshConnection/handlers/index.tsx
+++ b/src/components/dashboard/modals/sshConnection/handlers/index.tsx
@@ -1,0 +1,20 @@
+import deleteSshConnection from 'api/ssh-connections/ssh-delete';
+
+/**커넥션 삭제 api 호출 핸들러 */
+export const handleSshDelete = async (id: number, onClose: () => void, onSuccess?: () => void) => {
+  if (!id) {
+    alert('SSH 커넥션을 찾을 수 없습니다.');
+    return;
+  }
+
+  try {
+    await deleteSshConnection(id);
+    onClose();
+    onSuccess?.();
+    /**삭제 성공 시 화면 재렌더링 */
+    window.location.reload();
+  } catch (error) {
+    console.error('삭제 오류:', error);
+    alert(error instanceof Error ? error.message : '삭제 실패');
+  }
+};

--- a/src/components/dashboard/modals/sshConnection/index.tsx
+++ b/src/components/dashboard/modals/sshConnection/index.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { ModalContent, Overlay, CloseButton } from '@components/dashboard/modals/register-modal/index.style';
 import { ReactComponent as CloseIcon } from '../../../../assets/CloseIcon.svg';
-import { ModalProps } from '@components/dashboard/modals/register-modal/types';
+import { SshConnectionReadModalProps } from '@components/dashboard/modals/types';
+import ButtonGroup from '@components/dashboard/button';
+import { handleSshDelete } from './handlers';
 
-const SshConnectionReadModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+const SshConnectionReadModal: React.FC<SshConnectionReadModalProps> = ({ id, isOpen, onClose, onSuccess, inputValues, onSave }) => {
   if (!isOpen) return null;
+
+  const handleDelete = () => handleSshDelete(id, onClose, onSuccess);
 
   return ReactDOM.createPortal(
     <Overlay onClick={onClose}>
@@ -13,6 +17,7 @@ const SshConnectionReadModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
         <CloseButton onClick={onClose}>
           <CloseIcon />
         </CloseButton>
+        <ButtonGroup id={id} inputValues={inputValues} onSave={onSave} onDelete={handleDelete} />
       </ModalContent>
     </Overlay>,
     document.body

--- a/src/components/dashboard/modals/types/index.tsx
+++ b/src/components/dashboard/modals/types/index.tsx
@@ -1,0 +1,15 @@
+export interface RegisterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentPage: string;
+  fields: { label: string; placeholder: string }[];
+}
+
+export interface SshConnectionReadModalProps {
+  id: number;
+  isOpen: boolean;
+  onClose: () => void;
+  inputValues: string[];
+  onSave: () => void;
+  onSuccess?: () => void;
+}


### PR DESCRIPTION
## Motivation

- [HK-144](https://team-dopamine.atlassian.net/browse/HK-144?atlOrigin=eyJpIjoiMDk5NmZlODRhYjUzNDA2Mjg5ZDA4N2Q3MjRhNTdkOGYiLCJwIjoiaiJ9) 참고
- 사용자가 저장한 SSH 커넥션을 삭제하기 위함

## Problem Solving

- ssh 커넥션 삭제 api 호출 로직 구현(52850451d4c46d40ebd3991ea1f828eb49120963)
- 키체인/ssh커넥션 ReadModal 분리에 의한 props 타입 분리 (480d3f440c41be1879ed7f8b7a8d79bcc0b5293b)
- api 호출 핸들러 구현하여 삭제 api 연동(281609fe8278401ece5e2b5181560a5a7de4c3a8), (37a33fcf37017d9284692d77955ef1ac3233fcbd)
- 삭제 api 호출 성공 시 화면 새로고침

## To Reviewer

- 우선 모달창에 이전 버튼그룹 컴포넌트(`update|delete` 버튼) 그대로 가져와서 사용하고 있습니다. 추후 수정 api 연동 시 참고해주시면 됩니다::)


[HK-144]: https://team-dopamine.atlassian.net/browse/HK-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ