### PR TITLE
Feature(HK-166): 이메일 저장하기 로직 구현

### DIFF
--- a/src/pages/sign-in/sign-in-email/content/index.tsx
+++ b/src/pages/sign-in/sign-in-email/content/index.tsx
@@ -1,15 +1,74 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import postSignIn from 'api/sign-in';
 import { AuthContext } from 'api/context/auth-context';
 import { Container, ContentWrapper, Title, InputField, LoginButton, Label, ResetPasswordLink, ResetPasswordText } from '@pages/sign-in/sign-in-email/content/index.style';
 
+const EMAIL_COOKIE = 'rememberEmail';
+const COOKIE_MAX_DAYS = 30;
+
+function setCookie(name: string, value: string, days: number) {
+  const expires = new Date();
+  expires.setDate(expires.getDate() + days);
+  const isSecure = typeof window !== 'undefined' && window.location.protocol === 'https:';
+  const cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)};` + `expires=${expires.toUTCString()};path=/;SameSite=Lax;` + (isSecure ? 'Secure;' : '');
+  document.cookie = cookie;
+}
+
+function getCookie(name: string): string | null {
+  const target = `${encodeURIComponent(name)}=`;
+  const parts = document.cookie.split(';');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      return decodeURIComponent(trimmed.substring(target.length));
+    }
+  }
+  return null;
+}
+
+function deleteCookie(name: string) {
+  document.cookie = `${encodeURIComponent(name)}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;SameSite=Lax;`;
+}
+
 const SigninContent: React.FC = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
-  const { accessToken, login, isLoggedIn } = useContext(AuthContext)!;
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [rememberEmail, setRememberEmail] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const auth = useContext(AuthContext);
+
+  if (!auth) {
+    throw new Error('AuthContext.Provider로 감싸야 합니다.');
+  }
+
+  const { login } = auth;
+
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const saved = getCookie(EMAIL_COOKIE);
+    if (saved) {
+      setEmail(saved);
+      setRememberEmail(true);
+    }
+  }, []);
+
+  const toggleRemember = useCallback((checked: boolean, currentEmail: string) => {
+    setRememberEmail(checked);
+    if (checked) {
+      setCookie(EMAIL_COOKIE, currentEmail ?? '', COOKIE_MAX_DAYS);
+    } else {
+      deleteCookie(EMAIL_COOKIE);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (rememberEmail) {
+      setCookie(EMAIL_COOKIE, email, COOKIE_MAX_DAYS);
+    }
+  }, [email, rememberEmail]);
 
   const handleLogin = async () => {
     try {
@@ -18,6 +77,12 @@ const SigninContent: React.FC = () => {
 
       if (response.jwtTokenDto.accessToken && response.jwtTokenDto.refreshToken) {
         const { accessToken, refreshToken } = response.jwtTokenDto;
+
+        if (rememberEmail) {
+          setCookie(EMAIL_COOKIE, email, COOKIE_MAX_DAYS);
+        } else {
+          deleteCookie(EMAIL_COOKIE);
+        }
 
         login(accessToken, refreshToken);
         navigate('/');
@@ -29,32 +94,43 @@ const SigninContent: React.FC = () => {
     }
   };
 
-  const handleKeyUp = (e: { key: string }) => {
+  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      handleLogin();
+      void handleLogin();
     }
   };
 
   return (
-    <>
-      <Container>
-        <ContentWrapper>
-          <Title>Sign In</Title>
-          <Label style={{ alignSelf: 'flex-start' }}>Email</Label>
-          <InputField type="email" placeholder="Enter your email" value={email} onChange={(e) => setEmail(e.target.value)} onKeyUp={handleKeyUp} required />
+    <Container>
+      <ContentWrapper>
+        <Title>Sign In</Title>
+        <Label style={{ alignSelf: 'flex-start' }}>Email</Label>
+        <InputField type="email" placeholder="Enter your email" value={email} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)} onKeyUp={handleKeyUp} required />
 
-          <Label style={{ alignSelf: 'flex-start' }}>Password</Label>
-          <InputField type="password" placeholder="Enter your password" value={password} onChange={(e) => setPassword(e.target.value)} onKeyUp={handleKeyUp} required />
+        <div style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+          <input id="rememberEmail" type="checkbox" checked={rememberEmail} onChange={(e) => toggleRemember(e.target.checked, email)} />
+          <label htmlFor="rememberEmail">Remember Email</label>
+        </div>
 
-          <LoginButton onClick={handleLogin} disabled={loading}>
-            {loading ? 'Signing in...' : 'Sign In'}
-          </LoginButton>
-          <ResetPasswordText>
-            Forgot Your Password? <ResetPasswordLink href="/password/reset">Reset password</ResetPasswordLink>
-          </ResetPasswordText>
-        </ContentWrapper>
-      </Container>
-    </>
+        <Label style={{ alignSelf: 'flex-start', marginTop: 12 }}>Password</Label>
+        <InputField
+          type="password"
+          placeholder="Enter your password"
+          value={password}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+          onKeyUp={handleKeyUp}
+          required
+        />
+
+        <LoginButton onClick={handleLogin} disabled={loading}>
+          {loading ? 'Signing in...' : 'Sign In'}
+        </LoginButton>
+
+        <ResetPasswordText>
+          Forgot Your Password? <ResetPasswordLink href="/password/reset">Reset password</ResetPasswordLink>
+        </ResetPasswordText>
+      </ContentWrapper>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Motivation

- [HK-166](https://team-dopamine.atlassian.net/browse/HK-166) 참고
- 사용자가 이메일 로그인 시 이메일을 저장하고자 함

## Problem Solving

- **Remember Email** 체크박스 UI 추가
  - 체크박스 선택 시 입력한 이메일을 `쿠키`에 저장(30일 유지)
  - 체크 상태면 쿠키에 이메일 저장
  - 해제 상태면 쿠키 삭제
  - 초기 렌더링 시 저장된 이메일이 있으면 자동 입력 & 체크박스 활성화

<img width="313" height="285" alt="스크린샷 2025-09-25 오후 3 13 36" src="https://github.com/user-attachments/assets/3d2cfa26-4231-4d74-93c6-916493eb39f2" />

  ## To Reviewer

- `Sign In` 페이지가 전반적으로 영문이라 영어로 작성해두었는데 추후 언어 통일 협의 필요할 것 같습니다!


[HK-166]: https://team-dopamine.atlassian.net/browse/HK-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ